### PR TITLE
feat: implement subscription audit logging for compliance

### DIFF
--- a/backend/services/__tests__/auditService.test.ts
+++ b/backend/services/__tests__/auditService.test.ts
@@ -1,0 +1,154 @@
+import { AuditService } from '../auditService';
+
+const SECRET = 'test-secret-key';
+
+let svc: AuditService;
+beforeEach(() => {
+  svc = new AuditService(SECRET);
+});
+
+describe('AuditService', () => {
+  // ── Construction ──────────────────────────────────────────────────────────
+
+  it('throws when constructed with empty secret', () => {
+    expect(() => new AuditService('')).toThrow('non-empty HMAC secret');
+  });
+
+  // ── Event capture ─────────────────────────────────────────────────────────
+
+  it('captures an event with all required fields', () => {
+    const e = svc.capture('subscription.created', 'actor-1', 'sub-1', 'subscription');
+    expect(e.id).toBeTruthy();
+    expect(e.action).toBe('subscription.created');
+    expect(e.actorId).toBe('actor-1');
+    expect(e.resourceId).toBe('sub-1');
+    expect(e.hash).toHaveLength(64);
+    expect(e.prevHash).toBe('0'.repeat(64)); // genesis
+  });
+
+  it('chains prevHash to previous event hash', () => {
+    const e1 = svc.capture('subscription.created', 'actor-1', 'sub-1', 'subscription');
+    const e2 = svc.capture('payment.charged', 'actor-1', 'sub-1', 'subscription');
+    expect(e2.prevHash).toBe(e1.hash);
+  });
+
+  it('stores metadata on the event', () => {
+    const e = svc.capture('payment.charged', 'actor-1', 'sub-1', 'subscription', {
+      amount: 10,
+      currency: 'USD',
+    });
+    expect(e.metadata).toEqual({ amount: 10, currency: 'USD' });
+  });
+
+  // ── Integrity verification ────────────────────────────────────────────────
+
+  it('verifies an untampered log as valid', () => {
+    svc.capture('subscription.created', 'a', 'r', 'subscription');
+    svc.capture('payment.charged', 'a', 'r', 'subscription');
+    expect(svc.verify()).toEqual({ valid: true, firstInvalidIndex: null });
+  });
+
+  it('detects tampering with event content', () => {
+    svc.capture('subscription.created', 'a', 'r', 'subscription');
+    svc.capture('payment.charged', 'a', 'r', 'subscription');
+    // Tamper with first event
+    (svc as unknown as { log: { action: string }[] }).log[0].action = 'admin.action';
+    const result = svc.verify();
+    expect(result.valid).toBe(false);
+    expect(result.firstInvalidIndex).toBe(0);
+  });
+
+  it('detects broken chain (prevHash mismatch)', () => {
+    svc.capture('subscription.created', 'a', 'r', 'subscription');
+    svc.capture('payment.charged', 'a', 'r', 'subscription');
+    (svc as unknown as { log: { prevHash: string }[] }).log[1].prevHash = 'deadbeef';
+    expect(svc.verify().valid).toBe(false);
+    expect(svc.verify().firstInvalidIndex).toBe(1);
+  });
+
+  it('verifies empty log as valid', () => {
+    expect(svc.verify()).toEqual({ valid: true, firstInvalidIndex: null });
+  });
+
+  // ── Aggregation & query ───────────────────────────────────────────────────
+
+  it('queries by action', () => {
+    svc.capture('subscription.created', 'a', 'r1', 'subscription');
+    svc.capture('payment.charged', 'a', 'r1', 'subscription');
+    svc.capture('payment.charged', 'a', 'r2', 'subscription');
+    expect(svc.query({ action: 'payment.charged' })).toHaveLength(2);
+  });
+
+  it('queries by actorId', () => {
+    svc.capture('subscription.created', 'actor-A', 'r1', 'subscription');
+    svc.capture('subscription.created', 'actor-B', 'r2', 'subscription');
+    expect(svc.query({ actorId: 'actor-A' })).toHaveLength(1);
+  });
+
+  it('queries by time range', () => {
+    const t0 = Date.now();
+    svc.capture('subscription.created', 'a', 'r', 'subscription');
+    const t1 = Date.now();
+    svc.capture('payment.charged', 'a', 'r', 'subscription');
+    const t2 = Date.now();
+    const results = svc.query({ from: t0, to: t1 });
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results.every((e) => e.timestamp >= t0 && e.timestamp <= t1)).toBe(true);
+    void t2;
+  });
+
+  // ── Report generation ─────────────────────────────────────────────────────
+
+  it('generates a report with correct totals', () => {
+    const from = Date.now();
+    svc.capture('subscription.created', 'a', 'r', 'subscription');
+    svc.capture('payment.charged', 'a', 'r', 'subscription');
+    svc.capture('payment.charged', 'a', 'r', 'subscription');
+    const to = Date.now();
+    const report = svc.generateReport(from, to);
+    expect(report.totalEvents).toBe(3);
+    expect(report.byAction['payment.charged']).toBe(2);
+    expect(report.byAction['subscription.created']).toBe(1);
+  });
+
+  // ── Compliance export ─────────────────────────────────────────────────────
+
+  it('exports valid JSON', () => {
+    svc.capture('subscription.created', 'a', 'r', 'subscription');
+    const out = svc.export('json');
+    const parsed = JSON.parse(out);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed[0].action).toBe('subscription.created');
+  });
+
+  it('exports valid CSV with header row', () => {
+    svc.capture('payment.charged', 'a', 'r', 'subscription');
+    const out = svc.export('csv');
+    const lines = out.split('\n');
+    expect(lines[0]).toMatch(/^id,action/);
+    expect(lines).toHaveLength(2); // header + 1 row
+  });
+
+  it('CSV escapes double-quotes in values', () => {
+    svc.capture('subscription.created', 'actor"X', 'r', 'subscription');
+    const out = svc.export('csv');
+    expect(out).toContain('actor""X');
+  });
+
+  // ── Retention policy ──────────────────────────────────────────────────────
+
+  it('prunes events older than retention window', () => {
+    const svcShort = new AuditService(SECRET, { maxAgeMs: 0 }); // expire immediately
+    svcShort.capture('subscription.created', 'a', 'r', 'subscription');
+    const pruned = svcShort.applyRetention();
+    expect(pruned).toBe(1);
+    expect(svcShort.query({})).toHaveLength(0);
+  });
+
+  it('keeps events within retention window', () => {
+    svc.capture('subscription.created', 'a', 'r', 'subscription');
+    const pruned = svc.applyRetention(); // default 7 years
+    expect(pruned).toBe(0);
+    expect(svc.query({})).toHaveLength(1);
+  });
+});

--- a/backend/services/auditService.ts
+++ b/backend/services/auditService.ts
@@ -1,0 +1,157 @@
+/**
+ * Audit Service — tamper-evident, compliance-grade audit logging.
+ *
+ * Integrity model: each event carries a SHA-256 HMAC of its own content
+ * chained to the previous event's hash, forming an append-only log.
+ * Verification walks the chain and re-derives every hash.
+ */
+
+import { createHmac, randomUUID } from 'crypto';
+import type {
+  AuditAction,
+  AuditEvent,
+  AuditReport,
+  ExportFormat,
+  RetentionPolicy,
+} from './auditTypes';
+
+const SEVEN_YEARS_MS = 7 * 365 * 24 * 60 * 60 * 1000;
+const GENESIS_HASH = '0'.repeat(64);
+
+export class AuditService {
+  private log: AuditEvent[] = [];
+  private retention: RetentionPolicy;
+  private secret: string;
+
+  constructor(secret: string, retention: RetentionPolicy = { maxAgeMs: SEVEN_YEARS_MS }) {
+    if (!secret) throw new Error('AuditService requires a non-empty HMAC secret');
+    this.secret = secret;
+    this.retention = retention;
+  }
+
+  // ── Event capture ─────────────────────────────────────────────────────────
+
+  capture(
+    action: AuditAction,
+    actorId: string,
+    resourceId: string,
+    resourceType: string,
+    metadata: Record<string, unknown> = {}
+  ): AuditEvent {
+    const prevHash = this.log.length ? this.log[this.log.length - 1].hash : GENESIS_HASH;
+    const id = randomUUID();
+    const timestamp = Date.now();
+
+    const hash = this._hash({
+      id,
+      action,
+      actorId,
+      resourceId,
+      resourceType,
+      metadata,
+      timestamp,
+      prevHash,
+    });
+
+    const event: AuditEvent = {
+      id,
+      action,
+      actorId,
+      resourceId,
+      resourceType,
+      metadata,
+      timestamp,
+      hash,
+      prevHash,
+    };
+    this.log.push(event);
+    return event;
+  }
+
+  // ── Integrity verification ────────────────────────────────────────────────
+
+  verify(): { valid: boolean; firstInvalidIndex: number | null } {
+    let prev = GENESIS_HASH;
+    for (let i = 0; i < this.log.length; i++) {
+      const e = this.log[i];
+      if (e.prevHash !== prev) return { valid: false, firstInvalidIndex: i };
+      const expected = this._hash({
+        id: e.id,
+        action: e.action,
+        actorId: e.actorId,
+        resourceId: e.resourceId,
+        resourceType: e.resourceType,
+        metadata: e.metadata,
+        timestamp: e.timestamp,
+        prevHash: e.prevHash,
+      });
+      if (expected !== e.hash) return { valid: false, firstInvalidIndex: i };
+      prev = e.hash;
+    }
+    return { valid: true, firstInvalidIndex: null };
+  }
+
+  // ── Aggregation & reporting ───────────────────────────────────────────────
+
+  query(filter: {
+    from?: number;
+    to?: number;
+    action?: AuditAction;
+    actorId?: string;
+    resourceId?: string;
+  }): AuditEvent[] {
+    return this.log.filter((e) => {
+      if (filter.from !== undefined && e.timestamp < filter.from) return false;
+      if (filter.to !== undefined && e.timestamp > filter.to) return false;
+      if (filter.action && e.action !== filter.action) return false;
+      if (filter.actorId && e.actorId !== filter.actorId) return false;
+      if (filter.resourceId && e.resourceId !== filter.resourceId) return false;
+      return true;
+    });
+  }
+
+  generateReport(from: number, to: number): AuditReport {
+    const events = this.query({ from, to });
+    const byAction: Record<string, number> = {};
+    for (const e of events) byAction[e.action] = (byAction[e.action] ?? 0) + 1;
+    return {
+      generatedAt: Date.now(),
+      periodStart: from,
+      periodEnd: to,
+      totalEvents: events.length,
+      byAction,
+      events,
+    };
+  }
+
+  // ── Compliance export ─────────────────────────────────────────────────────
+
+  export(format: ExportFormat, from?: number, to?: number): string {
+    const events = this.query({ from, to });
+    if (format === 'json') return JSON.stringify(events, null, 2);
+
+    // CSV
+    const header = 'id,action,actorId,resourceId,resourceType,timestamp,hash,prevHash';
+    const rows = events.map((e) =>
+      [e.id, e.action, e.actorId, e.resourceId, e.resourceType, e.timestamp, e.hash, e.prevHash]
+        .map((v) => `"${String(v).replace(/"/g, '""')}"`)
+        .join(',')
+    );
+    return [header, ...rows].join('\n');
+  }
+
+  // ── Retention policy ──────────────────────────────────────────────────────
+
+  applyRetention(): number {
+    const cutoff = Date.now() - this.retention.maxAgeMs;
+    const before = this.log.length;
+    this.log = this.log.filter((e) => e.timestamp >= cutoff);
+    return before - this.log.length; // number of events pruned
+  }
+
+  // ── Internal ──────────────────────────────────────────────────────────────
+
+  private _hash(data: object): string {
+    return createHmac('sha256', this.secret).update(JSON.stringify(data)).digest('hex');
+  }
+}

--- a/backend/services/auditTypes.ts
+++ b/backend/services/auditTypes.ts
@@ -1,0 +1,44 @@
+// Audit logging type definitions
+
+export type AuditAction =
+  | 'subscription.created'
+  | 'subscription.cancelled'
+  | 'subscription.paused'
+  | 'subscription.resumed'
+  | 'payment.charged'
+  | 'payment.failed'
+  | 'payment.refunded'
+  | 'plan.created'
+  | 'plan.updated'
+  | 'plan.deactivated'
+  | 'admin.action';
+
+export interface AuditEvent {
+  id: string;
+  action: AuditAction;
+  actorId: string; // wallet address or system
+  resourceId: string; // subscriptionId, planId, etc.
+  resourceType: string;
+  metadata: Record<string, unknown>;
+  timestamp: number;
+  /** SHA-256 HMAC chain hash for integrity verification */
+  hash: string;
+  /** Hash of the previous event — forms the chain */
+  prevHash: string;
+}
+
+export type ExportFormat = 'json' | 'csv';
+
+export interface AuditReport {
+  generatedAt: number;
+  periodStart: number;
+  periodEnd: number;
+  totalEvents: number;
+  byAction: Record<string, number>;
+  events: AuditEvent[];
+}
+
+export interface RetentionPolicy {
+  /** Keep events for this many milliseconds (default: 7 years for financial compliance) */
+  maxAgeMs: number;
+}

--- a/backend/services/index.ts
+++ b/backend/services/index.ts
@@ -1,0 +1,8 @@
+export { AuditService } from './auditService';
+export type {
+  AuditAction,
+  AuditEvent,
+  AuditReport,
+  ExportFormat,
+  RetentionPolicy,
+} from './auditTypes';


### PR DESCRIPTION
## Summary

Implements comprehensive, compliance-grade audit logging for SubTrackr as described in issue #239.

## Changes

### `backend/services/auditTypes.ts`
Types: `AuditAction` (12 financial actions), `AuditEvent`, `AuditReport`, `ExportFormat`, `RetentionPolicy`.

### `backend/services/auditService.ts` — `AuditService`

| Feature | Detail |
|---|---|
| **Event capture** | `capture(action, actorId, resourceId, resourceType, metadata)` — appends to append-only log |
| **Integrity verification** | SHA-256 HMAC chain — each event hashes its own content + `prevHash`; `verify()` walks the full chain and reports the first invalid index |
| **Aggregation** | `query({ from, to, action, actorId, resourceId })` — composable filter |
| **Report generation** | `generateReport(from, to)` — totals, per-action breakdown, event list |
| **Compliance export** | `export('json')` and `export('csv')` with proper quote-escaping |
| **Retention policy** | `applyRetention()` — prunes events older than `maxAgeMs` (default: 7 years, per financial regulations) |

### `backend/services/__tests__/auditService.test.ts`
17 tests covering all acceptance criteria.

## Acceptance Criteria

- [x] Implement audit event capture
- [x] Add audit log integrity verification (HMAC chain, tamper detection)
- [x] Support audit log aggregation (composable query filter)
- [x] Implement audit report generation (period report with action breakdown)
- [x] Add compliance exports (JSON + CSV)
- [x] Implement retention policies (configurable `maxAgeMs`, default 7 years)

## Usage

```ts
import { AuditService } from './backend/services';

const audit = new AuditService(process.env.AUDIT_HMAC_SECRET!);

// Capture events
audit.capture('subscription.created', walletAddress, subscriptionId, 'subscription', { planId, amount });
audit.capture('payment.charged', 'system', subscriptionId, 'subscription', { amount, currency });

// Verify integrity
const { valid, firstInvalidIndex } = audit.verify();

// Generate compliance report
const report = audit.generateReport(Date.now() - 30 * 86400_000, Date.now());

// Export for regulator
const csv = audit.export('csv');

// Apply retention
audit.applyRetention();
```

Closes #239