### PR TITLE
feat: implement subscription secrets management system (#250)

### DIFF
--- a/backend/secrets/SecretsVault.ts
+++ b/backend/secrets/SecretsVault.ts
@@ -1,0 +1,266 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type Environment = 'development' | 'staging' | 'production';
+
+export interface SecretMetadata {
+  key: string;
+  env: Environment;
+  version: number;
+  createdAt: number;
+  rotatedAt: number | null;
+  /** Rotation interval in ms; null = no auto-rotation */
+  rotationIntervalMs: number | null;
+  /** Whether this secret has been soft-deleted */
+  deleted: boolean;
+}
+
+export interface SecretEntry {
+  meta: SecretMetadata;
+  /** Obfuscated value stored in AsyncStorage (base64) */
+  value: string;
+}
+
+export interface AuditEvent {
+  action: 'set' | 'get' | 'rotate' | 'delete' | 'recover' | 'inject';
+  key: string;
+  env: Environment;
+  timestamp: number;
+  success: boolean;
+  reason?: string;
+}
+
+export interface InjectedSecrets {
+  STELLAR_NETWORK: string;
+  CONTRACT_ID: string;
+  WEB3AUTH_CLIENT_ID: string;
+  [key: string]: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const VAULT_PREFIX = '@subtrackr:secrets:';
+const AUDIT_KEY = '@subtrackr:secrets:audit';
+const INDEX_KEY = '@subtrackr:secrets:index';
+const MAX_AUDIT_EVENTS = 1000;
+
+// ---------------------------------------------------------------------------
+// Minimal obfuscation (base64) — keeps values out of plain-text logs.
+// For production-grade encryption, replace with expo-crypto AES-GCM.
+// ---------------------------------------------------------------------------
+
+function encode(value: string): string {
+  return Buffer.from(value, 'utf8').toString('base64');
+}
+
+function decode(encoded: string): string {
+  return Buffer.from(encoded, 'base64').toString('utf8');
+}
+
+function storageKey(key: string, env: Environment): string {
+  return `${VAULT_PREFIX}${env}:${key}`;
+}
+
+// ---------------------------------------------------------------------------
+// SecretsVault
+// ---------------------------------------------------------------------------
+
+export class SecretsVault {
+  private readonly currentEnv: Environment;
+
+  constructor(env: Environment = 'development') {
+    this.currentEnv = env;
+  }
+
+  // ── Set / Get ─────────────────────────────────────────────────────────────
+
+  async set(
+    key: string,
+    value: string,
+    options: { env?: Environment; rotationIntervalMs?: number } = {}
+  ): Promise<SecretMetadata> {
+    const env = options.env ?? this.currentEnv;
+    const existing = await this._load(key, env);
+    const version = existing ? existing.meta.version + 1 : 1;
+
+    const meta: SecretMetadata = {
+      key,
+      env,
+      version,
+      createdAt: existing?.meta.createdAt ?? Date.now(),
+      rotatedAt: version > 1 ? Date.now() : null,
+      rotationIntervalMs: options.rotationIntervalMs ?? existing?.meta.rotationIntervalMs ?? null,
+      deleted: false,
+    };
+
+    const entry: SecretEntry = { meta, value: encode(value) };
+    await AsyncStorage.setItem(storageKey(key, env), JSON.stringify(entry));
+    await this._updateIndex(meta);
+    await this._audit({ action: version > 1 ? 'rotate' : 'set', key, env, success: true });
+    return meta;
+  }
+
+  async get(key: string, env?: Environment): Promise<string | null> {
+    const resolvedEnv = env ?? this.currentEnv;
+    const entry = await this._load(key, resolvedEnv);
+    if (!entry || entry.meta.deleted) {
+      await this._audit({
+        action: 'get',
+        key,
+        env: resolvedEnv,
+        success: false,
+        reason: 'not found or deleted',
+      });
+      return null;
+    }
+    await this._audit({ action: 'get', key, env: resolvedEnv, success: true });
+    return decode(entry.value);
+  }
+
+  // ── Rotation ──────────────────────────────────────────────────────────────
+
+  /** Rotate a secret to a new value, incrementing its version */
+  async rotate(key: string, newValue: string, env?: Environment): Promise<SecretMetadata> {
+    const resolvedEnv = env ?? this.currentEnv;
+    const existing = await this._load(key, resolvedEnv);
+    if (!existing || existing.meta.deleted) {
+      await this._audit({
+        action: 'rotate',
+        key,
+        env: resolvedEnv,
+        success: false,
+        reason: 'secret not found',
+      });
+      throw new Error(`Secret "${key}" not found in ${resolvedEnv}`);
+    }
+    return this.set(key, newValue, {
+      env: resolvedEnv,
+      rotationIntervalMs: existing.meta.rotationIntervalMs ?? undefined,
+    });
+  }
+
+  /** Returns secrets whose rotation interval has elapsed */
+  async getDueForRotation(env?: Environment): Promise<SecretMetadata[]> {
+    const resolvedEnv = env ?? this.currentEnv;
+    const index = await this._getIndex();
+    const now = Date.now();
+    return index.filter(
+      (m) =>
+        m.env === resolvedEnv &&
+        !m.deleted &&
+        m.rotationIntervalMs !== null &&
+        now - (m.rotatedAt ?? m.createdAt) >= m.rotationIntervalMs
+    );
+  }
+
+  // ── Environment-specific secrets ──────────────────────────────────────────
+
+  /** List all non-deleted secrets for a given environment */
+  async listByEnv(env?: Environment): Promise<SecretMetadata[]> {
+    const resolvedEnv = env ?? this.currentEnv;
+    const index = await this._getIndex();
+    return index.filter((m) => m.env === resolvedEnv && !m.deleted);
+  }
+
+  // ── Secrets injection ─────────────────────────────────────────────────────
+
+  /**
+   * Inject all secrets for the current environment into a flat object.
+   * Use this to populate app config at startup.
+   */
+  async inject(env?: Environment): Promise<Partial<InjectedSecrets>> {
+    const resolvedEnv = env ?? this.currentEnv;
+    const metas = await this.listByEnv(resolvedEnv);
+    const result: Partial<InjectedSecrets> = {};
+    for (const meta of metas) {
+      const value = await this.get(meta.key, resolvedEnv);
+      if (value !== null) result[meta.key] = value;
+    }
+    await this._audit({ action: 'inject', key: '*', env: resolvedEnv, success: true });
+    return result;
+  }
+
+  // ── Soft delete ───────────────────────────────────────────────────────────
+
+  async delete(key: string, env?: Environment): Promise<void> {
+    const resolvedEnv = env ?? this.currentEnv;
+    const entry = await this._load(key, resolvedEnv);
+    if (!entry) return;
+    entry.meta.deleted = true;
+    await AsyncStorage.setItem(storageKey(key, resolvedEnv), JSON.stringify(entry));
+    await this._updateIndex(entry.meta);
+    await this._audit({ action: 'delete', key, env: resolvedEnv, success: true });
+  }
+
+  // ── Recovery ──────────────────────────────────────────────────────────────
+
+  /** Recover a soft-deleted secret */
+  async recover(key: string, env?: Environment): Promise<SecretMetadata> {
+    const resolvedEnv = env ?? this.currentEnv;
+    const entry = await this._load(key, resolvedEnv);
+    if (!entry) {
+      await this._audit({
+        action: 'recover',
+        key,
+        env: resolvedEnv,
+        success: false,
+        reason: 'not found',
+      });
+      throw new Error(`Secret "${key}" not found in ${resolvedEnv}`);
+    }
+    entry.meta.deleted = false;
+    await AsyncStorage.setItem(storageKey(key, resolvedEnv), JSON.stringify(entry));
+    await this._updateIndex(entry.meta);
+    await this._audit({ action: 'recover', key, env: resolvedEnv, success: true });
+    return entry.meta;
+  }
+
+  // ── Audit log ─────────────────────────────────────────────────────────────
+
+  async getAuditLog(limit = 100): Promise<AuditEvent[]> {
+    const raw = await AsyncStorage.getItem(AUDIT_KEY);
+    const events: AuditEvent[] = raw ? JSON.parse(raw) : [];
+    return events.slice(-limit);
+  }
+
+  async clearAuditLog(): Promise<void> {
+    await AsyncStorage.removeItem(AUDIT_KEY);
+  }
+
+  // ── Private ───────────────────────────────────────────────────────────────
+
+  private async _load(key: string, env: Environment): Promise<SecretEntry | null> {
+    const raw = await AsyncStorage.getItem(storageKey(key, env));
+    return raw ? (JSON.parse(raw) as SecretEntry) : null;
+  }
+
+  private async _getIndex(): Promise<SecretMetadata[]> {
+    const raw = await AsyncStorage.getItem(INDEX_KEY);
+    return raw ? (JSON.parse(raw) as SecretMetadata[]) : [];
+  }
+
+  private async _updateIndex(meta: SecretMetadata): Promise<void> {
+    const index = await this._getIndex();
+    const idx = index.findIndex((m) => m.key === meta.key && m.env === meta.env);
+    if (idx >= 0) index[idx] = meta;
+    else index.push(meta);
+    await AsyncStorage.setItem(INDEX_KEY, JSON.stringify(index));
+  }
+
+  private async _audit(event: Omit<AuditEvent, 'timestamp'>): Promise<void> {
+    const raw = await AsyncStorage.getItem(AUDIT_KEY);
+    const events: AuditEvent[] = raw ? JSON.parse(raw) : [];
+    events.push({ ...event, timestamp: Date.now() });
+    if (events.length > MAX_AUDIT_EVENTS) events.splice(0, events.length - MAX_AUDIT_EVENTS);
+    await AsyncStorage.setItem(AUDIT_KEY, JSON.stringify(events));
+  }
+}
+
+export const secretsVault = new SecretsVault(
+  (process.env['APP_ENV'] as Environment | undefined) ?? 'development'
+);

--- a/backend/secrets/__tests__/SecretsVault.test.ts
+++ b/backend/secrets/__tests__/SecretsVault.test.ts
@@ -1,0 +1,213 @@
+import { SecretsVault } from '../SecretsVault';
+
+// ---------------------------------------------------------------------------
+// AsyncStorage mock
+// ---------------------------------------------------------------------------
+
+const store: Record<string, string> = {};
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(async (key: string) => store[key] ?? null),
+  setItem: jest.fn(async (key: string, value: string) => {
+    store[key] = value;
+  }),
+  removeItem: jest.fn(async (key: string) => {
+    delete store[key];
+  }),
+  multiGet: jest.fn(async (keys: string[]) => keys.map((k) => [k, store[k] ?? null])),
+  multiSet: jest.fn(async (pairs: [string, string][]) => {
+    pairs.forEach(([k, v]) => {
+      store[k] = v;
+    });
+  }),
+  multiRemove: jest.fn(async (keys: string[]) => {
+    keys.forEach((k) => delete store[k]);
+  }),
+}));
+
+beforeEach(() => Object.keys(store).forEach((k) => delete store[k]));
+
+describe('SecretsVault', () => {
+  let vault: SecretsVault;
+
+  beforeEach(() => {
+    vault = new SecretsVault('development');
+  });
+
+  // ── Vault set / get ───────────────────────────────────────────────────────
+
+  it('stores and retrieves a secret', async () => {
+    await vault.set('WEB3AUTH_CLIENT_ID', 'abc123');
+    expect(await vault.get('WEB3AUTH_CLIENT_ID')).toBe('abc123');
+  });
+
+  it('returns null for unknown secret', async () => {
+    expect(await vault.get('MISSING_KEY')).toBeNull();
+  });
+
+  it('value is not stored as plain text', async () => {
+    await vault.set('CONTRACT_ID', 'CB64SECRET');
+    const raw = store['@subtrackr:secrets:development:CONTRACT_ID'];
+    expect(raw).not.toContain('CB64SECRET');
+  });
+
+  it('increments version on overwrite', async () => {
+    await vault.set('KEY', 'v1');
+    const meta = await vault.set('KEY', 'v2');
+    expect(meta.version).toBe(2);
+    expect(await vault.get('KEY')).toBe('v2');
+  });
+
+  // ── Secrets rotation ──────────────────────────────────────────────────────
+
+  it('rotates a secret to a new value', async () => {
+    await vault.set('API_KEY', 'old-value');
+    const meta = await vault.rotate('API_KEY', 'new-value');
+    expect(meta.version).toBe(2);
+    expect(meta.rotatedAt).not.toBeNull();
+    expect(await vault.get('API_KEY')).toBe('new-value');
+  });
+
+  it('throws when rotating a non-existent secret', async () => {
+    await expect(vault.rotate('GHOST', 'value')).rejects.toThrow(/not found/i);
+  });
+
+  it('identifies secrets due for rotation', async () => {
+    await vault.set('ROTATING_KEY', 'val', { rotationIntervalMs: 1 }); // 1ms interval
+    await new Promise((r) => setTimeout(r, 5));
+    const due = await vault.getDueForRotation();
+    expect(due.some((m) => m.key === 'ROTATING_KEY')).toBe(true);
+  });
+
+  it('does not flag secrets not yet due', async () => {
+    await vault.set('FRESH_KEY', 'val', { rotationIntervalMs: 999_999 });
+    const due = await vault.getDueForRotation();
+    expect(due.some((m) => m.key === 'FRESH_KEY')).toBe(false);
+  });
+
+  // ── Environment-specific secrets ──────────────────────────────────────────
+
+  it('isolates secrets by environment', async () => {
+    await vault.set('STELLAR_NETWORK', 'testnet', { env: 'development' });
+    await vault.set('STELLAR_NETWORK', 'mainnet', { env: 'production' });
+    expect(await vault.get('STELLAR_NETWORK', 'development')).toBe('testnet');
+    expect(await vault.get('STELLAR_NETWORK', 'production')).toBe('mainnet');
+  });
+
+  it('lists secrets for a specific environment only', async () => {
+    await vault.set('KEY_A', 'a', { env: 'staging' });
+    await vault.set('KEY_B', 'b', { env: 'production' });
+    const stagingSecrets = await vault.listByEnv('staging');
+    expect(stagingSecrets.every((m) => m.env === 'staging')).toBe(true);
+    expect(stagingSecrets.some((m) => m.key === 'KEY_A')).toBe(true);
+    expect(stagingSecrets.some((m) => m.key === 'KEY_B')).toBe(false);
+  });
+
+  // ── Secrets injection ─────────────────────────────────────────────────────
+
+  it('injects all env secrets into a flat object', async () => {
+    await vault.set('STELLAR_NETWORK', 'testnet');
+    await vault.set('CONTRACT_ID', 'CB64XYZ');
+    const injected = await vault.inject();
+    expect(injected['STELLAR_NETWORK']).toBe('testnet');
+    expect(injected['CONTRACT_ID']).toBe('CB64XYZ');
+  });
+
+  it('inject does not include deleted secrets', async () => {
+    await vault.set('OLD_KEY', 'value');
+    await vault.delete('OLD_KEY');
+    const injected = await vault.inject();
+    expect(injected['OLD_KEY']).toBeUndefined();
+  });
+
+  // ── Soft delete ───────────────────────────────────────────────────────────
+
+  it('soft-deletes a secret (get returns null)', async () => {
+    await vault.set('TEMP_KEY', 'value');
+    await vault.delete('TEMP_KEY');
+    expect(await vault.get('TEMP_KEY')).toBeNull();
+  });
+
+  it('deleted secret excluded from listByEnv', async () => {
+    await vault.set('DEL_KEY', 'value');
+    await vault.delete('DEL_KEY');
+    const list = await vault.listByEnv();
+    expect(list.some((m) => m.key === 'DEL_KEY')).toBe(false);
+  });
+
+  // ── Secrets recovery ──────────────────────────────────────────────────────
+
+  it('recovers a soft-deleted secret', async () => {
+    await vault.set('RECOVER_KEY', 'secret-value');
+    await vault.delete('RECOVER_KEY');
+    await vault.recover('RECOVER_KEY');
+    expect(await vault.get('RECOVER_KEY')).toBe('secret-value');
+  });
+
+  it('throws when recovering a non-existent secret', async () => {
+    await expect(vault.recover('GHOST_KEY')).rejects.toThrow(/not found/i);
+  });
+
+  // ── Audit logging ─────────────────────────────────────────────────────────
+
+  it('logs set action', async () => {
+    await vault.set('AUDIT_KEY', 'val');
+    const log = await vault.getAuditLog();
+    expect(log.some((e) => e.action === 'set' && e.key === 'AUDIT_KEY')).toBe(true);
+  });
+
+  it('logs get action', async () => {
+    await vault.set('AUDIT_KEY', 'val');
+    await vault.get('AUDIT_KEY');
+    const log = await vault.getAuditLog();
+    expect(log.some((e) => e.action === 'get' && e.key === 'AUDIT_KEY' && e.success)).toBe(true);
+  });
+
+  it('logs failed get for missing secret', async () => {
+    await vault.get('MISSING');
+    const log = await vault.getAuditLog();
+    expect(log.some((e) => e.action === 'get' && e.key === 'MISSING' && !e.success)).toBe(true);
+  });
+
+  it('logs rotate action', async () => {
+    await vault.set('ROT_KEY', 'v1');
+    await vault.rotate('ROT_KEY', 'v2');
+    const log = await vault.getAuditLog();
+    expect(log.some((e) => e.action === 'rotate' && e.key === 'ROT_KEY')).toBe(true);
+  });
+
+  it('logs delete action', async () => {
+    await vault.set('DEL_KEY', 'val');
+    await vault.delete('DEL_KEY');
+    const log = await vault.getAuditLog();
+    expect(log.some((e) => e.action === 'delete' && e.key === 'DEL_KEY')).toBe(true);
+  });
+
+  it('logs recover action', async () => {
+    await vault.set('REC_KEY', 'val');
+    await vault.delete('REC_KEY');
+    await vault.recover('REC_KEY');
+    const log = await vault.getAuditLog();
+    expect(log.some((e) => e.action === 'recover' && e.key === 'REC_KEY')).toBe(true);
+  });
+
+  it('logs inject action', async () => {
+    await vault.inject();
+    const log = await vault.getAuditLog();
+    expect(log.some((e) => e.action === 'inject')).toBe(true);
+  });
+
+  it('clears audit log', async () => {
+    await vault.set('K', 'v');
+    await vault.clearAuditLog();
+    expect(await vault.getAuditLog()).toHaveLength(0);
+  });
+
+  it('audit log includes timestamp and env', async () => {
+    await vault.set('TS_KEY', 'val');
+    const log = await vault.getAuditLog();
+    const event = log.find((e) => e.key === 'TS_KEY');
+    expect(event?.timestamp).toBeGreaterThan(0);
+    expect(event?.env).toBe('development');
+  });
+});


### PR DESCRIPTION
## Summary

Implements comprehensive secrets management for SubTrackr as described in issue #250.

## Changes

### `backend/secrets/SecretsVault.ts`

| Acceptance Criterion | Implementation |
|---|---|
| Secrets vault | `SecretsVault` class — AsyncStorage-backed, values obfuscated (base64; swap-ready for AES-GCM), versioned manifest index |
| Secrets rotation | `rotate(key, newValue)` increments version + sets `rotatedAt`; `getDueForRotation()` returns secrets past their `rotationIntervalMs` |
| Environment-specific secrets | `set/get/list` all accept `env: 'development' \| 'staging' \| 'production'`; storage keys are namespaced per env |
| Secrets injection | `inject(env?)` returns a flat `InjectedSecrets` object (STELLAR_NETWORK, CONTRACT_ID, WEB3AUTH_CLIENT_ID, …) for app startup |
| Audit logging | Every `set`, `get`, `rotate`, `delete`, `recover`, `inject` writes an `AuditEvent` with timestamp, env, success flag, and optional reason; capped at 1000 events |
| Secrets recovery | Soft-delete via `delete()`; `recover(key)` restores the value and clears the deleted flag |

### `backend/secrets/__tests__/SecretsVault.test.ts`
- 25 tests covering all 6 acceptance criteria

## Test Results

```
PASS backend/secrets/__tests__/SecretsVault.test.ts
  SecretsVault
    ✓ stores and retrieves a secret
    ✓ returns null for unknown secret
    ✓ value is not stored as plain text
    ✓ increments version on overwrite
    ✓ rotates a secret to a new value
    ✓ throws when rotating a non-existent secret
    ✓ identifies secrets due for rotation
    ✓ does not flag secrets not yet due
    ✓ isolates secrets by environment
    ✓ lists secrets for a specific environment only
    ✓ injects all env secrets into a flat object
    ✓ inject does not include deleted secrets
    ✓ soft-deletes a secret (get returns null)
    ✓ deleted secret excluded from listByEnv
    ✓ recovers a soft-deleted secret
    ✓ throws when recovering a non-existent secret
    ✓ logs set action
    ✓ logs get action
    ✓ logs failed get for missing secret
    ✓ logs rotate action
    ✓ logs delete action
    ✓ logs recover action
    ✓ logs inject action
    ✓ clears audit log
    ✓ audit log includes timestamp and env

Tests: 25 passed, 25 total
```

## Acceptance Criteria

- [x] Implement secrets vault (versioned, obfuscated, AsyncStorage-backed)
- [x] Add secrets rotation (`rotate()`, `getDueForRotation()`, `rotationIntervalMs`)
- [x] Support environment-specific secrets (dev/staging/prod isolation)
- [x] Implement secrets injection (`inject()` → flat config object at startup)
- [x] Add audit logging for secrets (all 6 actions logged with timestamp + env)
- [x] Implement secrets recovery (soft-delete + `recover()`)

Closes #250