### PR TITLE
feat: implement subscription caching layer with offline support

### DIFF
--- a/app/tests/integration/contract-store.integration.test.ts
+++ b/app/tests/integration/contract-store.integration.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Integration tests: contract ↔ store interaction
+ *
+ * Verifies that the subscriptionStore correctly integrates with the
+ * notificationService (the "contract" layer) on every mutation.
+ */
+
+import { act } from 'react';
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useSubscriptionStore } from '../../../src/store/subscriptionStore';
+import { SubscriptionCategory, BillingCycle } from '../../../src/types/subscription';
+import { makeSubscription, makeSubscriptionFormData, resetIdCounter } from './factories';
+
+// ── In-memory AsyncStorage ────────────────────────────────────────────────────
+const mockMemoryStore = new Map<string, string>();
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: jest.fn((key: string, value: string) => {
+    mockMemoryStore.set(key, value);
+    return Promise.resolve();
+  }),
+  getItem: jest.fn((key: string) => Promise.resolve(mockMemoryStore.get(key) ?? null)),
+  removeItem: jest.fn((key: string) => {
+    mockMemoryStore.delete(key);
+    return Promise.resolve();
+  }),
+  clear: jest.fn(() => {
+    mockMemoryStore.clear();
+    return Promise.resolve();
+  }),
+}));
+
+// ── Notification service mock (the "contract" side) ───────────────────────────
+const mockSyncRenewalReminders = jest.fn(() => Promise.resolve());
+const mockPresentChargeSuccess = jest.fn(() => Promise.resolve());
+const mockPresentChargeFailed = jest.fn(() => Promise.resolve());
+
+jest.mock('../../../src/services/notificationService', () => ({
+  syncRenewalReminders: (...args: unknown[]) => mockSyncRenewalReminders(...args),
+  presentChargeSuccessNotification: (...args: unknown[]) => mockPresentChargeSuccess(...args),
+  presentChargeFailedNotification: (...args: unknown[]) => mockPresentChargeFailed(...args),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+function resetStore() {
+  useSubscriptionStore.setState({
+    subscriptions: [],
+    stats: {
+      totalActive: 0,
+      totalMonthlySpend: 0,
+      totalYearlySpend: 0,
+      categoryBreakdown: {} as never,
+    },
+    isLoading: false,
+    error: null,
+  });
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  mockMemoryStore.clear();
+  (AsyncStorage.setItem as jest.Mock).mockClear();
+  mockSyncRenewalReminders.mockClear();
+  mockPresentChargeSuccess.mockClear();
+  mockPresentChargeFailed.mockClear();
+  resetStore();
+  resetIdCounter();
+});
+
+afterEach(() => {
+  jest.runAllTimers();
+  jest.useRealTimers();
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+describe('contract-store integration', () => {
+  it('addSubscription calls syncRenewalReminders with the new subscription', async () => {
+    const formData = makeSubscriptionFormData({ name: 'GitHub Copilot' });
+
+    await act(async () => {
+      await useSubscriptionStore.getState().addSubscription(formData);
+    });
+
+    expect(mockSyncRenewalReminders).toHaveBeenCalledTimes(1);
+    const [subs] = mockSyncRenewalReminders.mock.calls[0] as [unknown[]];
+    expect(Array.isArray(subs)).toBe(true);
+    expect((subs as { name: string }[]).some((s) => s.name === 'GitHub Copilot')).toBe(true);
+  });
+
+  it('updateSubscription propagates updated list to syncRenewalReminders', async () => {
+    await act(async () => {
+      await useSubscriptionStore.getState().addSubscription(makeSubscriptionFormData());
+    });
+    mockSyncRenewalReminders.mockClear();
+
+    const id = useSubscriptionStore.getState().subscriptions[0].id;
+
+    await act(async () => {
+      await useSubscriptionStore.getState().updateSubscription(id, { price: 19.99 });
+    });
+
+    expect(mockSyncRenewalReminders).toHaveBeenCalledTimes(1);
+    const [subs] = mockSyncRenewalReminders.mock.calls[0] as [{ price: number }[]];
+    expect(subs[0].price).toBe(19.99);
+  });
+
+  it('deleteSubscription syncs reminders after removal', async () => {
+    const sub1 = makeSubscription({ id: 'keep', name: 'Keep Me' });
+    const sub2 = makeSubscription({ id: 'remove', name: 'Remove Me' });
+    useSubscriptionStore.setState({ subscriptions: [sub1, sub2] });
+    mockSyncRenewalReminders.mockClear();
+
+    await act(async () => {
+      await useSubscriptionStore.getState().deleteSubscription('remove');
+    });
+
+    expect(mockSyncRenewalReminders).toHaveBeenCalledTimes(1);
+    const [subs] = mockSyncRenewalReminders.mock.calls[0] as [{ name: string }[]];
+    expect(subs.every((s) => s.name !== 'Remove Me')).toBe(true);
+  });
+
+  it('recordBillingOutcome success fires charge-success notification', async () => {
+    await act(async () => {
+      await useSubscriptionStore
+        .getState()
+        .addSubscription(
+          makeSubscriptionFormData({ name: 'Vercel Pro', notificationsEnabled: true })
+        );
+    });
+    const id = useSubscriptionStore.getState().subscriptions[0].id;
+
+    await act(async () => {
+      await useSubscriptionStore.getState().recordBillingOutcome(id, 'success');
+    });
+
+    expect(mockPresentChargeSuccess).toHaveBeenCalledTimes(1);
+    expect(mockPresentChargeFailed).not.toHaveBeenCalled();
+  });
+
+  it('recordBillingOutcome failure fires charge-failed notification', async () => {
+    await act(async () => {
+      await useSubscriptionStore
+        .getState()
+        .addSubscription(makeSubscriptionFormData({ notificationsEnabled: true }));
+    });
+    const id = useSubscriptionStore.getState().subscriptions[0].id;
+
+    await act(async () => {
+      await useSubscriptionStore.getState().recordBillingOutcome(id, 'failed');
+    });
+
+    expect(mockPresentChargeFailed).toHaveBeenCalledTimes(1);
+    expect(mockPresentChargeSuccess).not.toHaveBeenCalled();
+  });
+
+  it('recordBillingOutcome skips notifications when notificationsEnabled is false', async () => {
+    await act(async () => {
+      await useSubscriptionStore
+        .getState()
+        .addSubscription(makeSubscriptionFormData({ notificationsEnabled: false }));
+    });
+    const id = useSubscriptionStore.getState().subscriptions[0].id;
+
+    await act(async () => {
+      await useSubscriptionStore.getState().recordBillingOutcome(id, 'success');
+    });
+
+    expect(mockPresentChargeSuccess).not.toHaveBeenCalled();
+  });
+
+  it('stats stay consistent after a full add → toggle → delete cycle', async () => {
+    await act(async () => {
+      await useSubscriptionStore
+        .getState()
+        .addSubscription(
+          makeSubscriptionFormData({ price: 10, billingCycle: BillingCycle.MONTHLY })
+        );
+    });
+    expect(useSubscriptionStore.getState().stats.totalActive).toBe(1);
+
+    const id = useSubscriptionStore.getState().subscriptions[0].id;
+
+    await act(async () => {
+      await useSubscriptionStore.getState().toggleSubscriptionStatus(id);
+    });
+    expect(useSubscriptionStore.getState().stats.totalActive).toBe(0);
+
+    await act(async () => {
+      await useSubscriptionStore.getState().deleteSubscription(id);
+    });
+    expect(useSubscriptionStore.getState().subscriptions).toHaveLength(0);
+    expect(useSubscriptionStore.getState().stats.totalActive).toBe(0);
+  });
+
+  it('categoryBreakdown reflects multiple categories correctly', async () => {
+    await act(async () => {
+      await useSubscriptionStore
+        .getState()
+        .addSubscription(makeSubscriptionFormData({ category: SubscriptionCategory.STREAMING }));
+      await useSubscriptionStore
+        .getState()
+        .addSubscription(makeSubscriptionFormData({ category: SubscriptionCategory.GAMING }));
+      await useSubscriptionStore
+        .getState()
+        .addSubscription(makeSubscriptionFormData({ category: SubscriptionCategory.GAMING }));
+    });
+
+    const { categoryBreakdown } = useSubscriptionStore.getState().stats;
+    expect(categoryBreakdown[SubscriptionCategory.STREAMING]).toBe(1);
+    expect(categoryBreakdown[SubscriptionCategory.GAMING]).toBe(2);
+  });
+});

--- a/app/tests/integration/factories.ts
+++ b/app/tests/integration/factories.ts
@@ -1,0 +1,84 @@
+/**
+ * Test data factories for integration tests.
+ * Provides deterministic, minimal fixtures for subscriptions, wallets, and streams.
+ */
+
+import { SubscriptionCategory, BillingCycle } from '../../../src/types/subscription';
+import type { Subscription, SubscriptionFormData } from '../../../src/types/subscription';
+import type { Wallet, CryptoStream } from '../../../src/types/wallet';
+
+let _idCounter = 0;
+const nextId = () => `test-${++_idCounter}`;
+
+export function resetIdCounter(): void {
+  _idCounter = 0;
+}
+
+export function makeSubscriptionFormData(
+  overrides: Partial<SubscriptionFormData> = {}
+): SubscriptionFormData {
+  return {
+    name: 'Test Service',
+    category: SubscriptionCategory.SOFTWARE,
+    price: 9.99,
+    currency: 'USD',
+    billingCycle: BillingCycle.MONTHLY,
+    nextBillingDate: new Date('2026-05-01'),
+    notificationsEnabled: true,
+    isCryptoEnabled: false,
+    ...overrides,
+  };
+}
+
+export function makeSubscription(overrides: Partial<Subscription> = {}): Subscription {
+  const now = new Date('2026-04-01T00:00:00Z');
+  return {
+    id: nextId(),
+    name: 'Test Service',
+    category: SubscriptionCategory.SOFTWARE,
+    price: 9.99,
+    currency: 'USD',
+    billingCycle: BillingCycle.MONTHLY,
+    nextBillingDate: new Date('2026-05-01'),
+    isActive: true,
+    notificationsEnabled: true,
+    isCryptoEnabled: false,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+export function makeWallet(overrides: Partial<Wallet> = {}): Wallet {
+  return {
+    address: '0x742d35Cc6634C0532925a3b844Bc9e7595f0fAb1',
+    chainId: 1,
+    isConnected: true,
+    balance: '1.0',
+    tokens: [
+      {
+        symbol: 'ETH',
+        name: 'Ethereum',
+        address: '0x0000000000000000000000000000000000000000',
+        balance: '1.0',
+        decimals: 18,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+export function makeCryptoStream(overrides: Partial<CryptoStream> = {}): CryptoStream {
+  return {
+    id: nextId(),
+    subscriptionId: nextId(),
+    token: 'USDC',
+    amount: 10,
+    flowRate: '0.001',
+    startDate: new Date('2026-04-01'),
+    isActive: true,
+    protocol: 'superfluid',
+    streamId: `stream_${nextId()}`,
+    ...overrides,
+  };
+}

--- a/app/tests/integration/notification-delivery.integration.test.ts
+++ b/app/tests/integration/notification-delivery.integration.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Integration tests: notification delivery
+ *
+ * Verifies that the notificationService correctly schedules, cancels,
+ * and presents notifications in response to subscription lifecycle events.
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { Platform } from 'react-native';
+import * as Notifications from 'expo-notifications';
+import {
+  syncRenewalReminders,
+  presentChargeSuccessNotification,
+  presentChargeFailedNotification,
+  presentTransactionQueueNotification,
+  requestNotificationPermissions,
+  NOTIFICATION_DATA_TYPE,
+} from '../../../src/services/notificationService';
+import { makeSubscription, resetIdCounter } from './factories';
+import { BillingCycle } from '../../../src/types/subscription';
+
+// ── Platform: simulate iOS (notifications supported) ─────────────────────────
+jest.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+}));
+
+// ── expo-notifications mock ───────────────────────────────────────────────────
+const mockSchedule = jest.fn(() => Promise.resolve('notif-id'));
+const mockGetScheduled = jest.fn(() => Promise.resolve([]));
+const mockCancel = jest.fn(() => Promise.resolve());
+const mockGetPermissions = jest.fn(() =>
+  Promise.resolve({ status: Notifications.PermissionStatus.GRANTED })
+);
+const mockRequestPermissions = jest.fn(() =>
+  Promise.resolve({ status: Notifications.PermissionStatus.GRANTED })
+);
+const mockSetHandler = jest.fn();
+const mockSetChannel = jest.fn(() => Promise.resolve());
+
+jest.mock('expo-notifications', () => ({
+  PermissionStatus: { GRANTED: 'granted', DENIED: 'denied', UNDETERMINED: 'undetermined' },
+  AndroidImportance: { HIGH: 4 },
+  AndroidNotificationVisibility: { PUBLIC: 1 },
+  SchedulableTriggerInputTypes: { DATE: 'date' },
+  setNotificationHandler: (...args: unknown[]) => mockSetHandler(...args),
+  setNotificationChannelAsync: (...args: unknown[]) => mockSetChannel(...args),
+  getPermissionsAsync: () => mockGetPermissions(),
+  requestPermissionsAsync: () => mockRequestPermissions(),
+  scheduleNotificationAsync: (...args: unknown[]) => mockSchedule(...args),
+  getAllScheduledNotificationsAsync: () => mockGetScheduled(),
+  cancelScheduledNotificationAsync: (...args: unknown[]) => mockCancel(...args),
+}));
+
+beforeEach(() => {
+  mockSchedule.mockClear();
+  mockGetScheduled.mockClear();
+  mockCancel.mockClear();
+  mockGetPermissions.mockClear();
+  mockRequestPermissions.mockClear();
+  mockSetHandler.mockClear();
+  mockSetChannel.mockClear();
+  resetIdCounter();
+  // Reset handler flag between tests
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (global as any).__handlerConfigured = false;
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+describe('notification delivery integration', () => {
+  it('requestNotificationPermissions returns GRANTED when already granted', async () => {
+    const status = await requestNotificationPermissions();
+    expect(status).toBe(Notifications.PermissionStatus.GRANTED);
+  });
+
+  it('presentChargeSuccessNotification schedules an immediate notification', async () => {
+    const sub = makeSubscription({ name: 'Linear', price: 8, currency: 'USD' });
+    await presentChargeSuccessNotification(sub);
+
+    expect(mockSchedule).toHaveBeenCalledTimes(1);
+    const [payload] = mockSchedule.mock.calls[0] as [
+      { content: { title: string; data: { type: string } }; trigger: null },
+    ];
+    expect(payload.content.title).toContain('Linear');
+    expect(payload.content.data.type).toBe(NOTIFICATION_DATA_TYPE.CHARGE_SUCCESS);
+    expect(payload.trigger).toBeNull();
+  });
+
+  it('presentChargeFailedNotification schedules an immediate notification', async () => {
+    const sub = makeSubscription({ name: 'Figma' });
+    await presentChargeFailedNotification(sub);
+
+    expect(mockSchedule).toHaveBeenCalledTimes(1);
+    const [payload] = mockSchedule.mock.calls[0] as [
+      { content: { title: string; data: { type: string } }; trigger: null },
+    ];
+    expect(payload.content.title).toContain('Figma');
+    expect(payload.content.data.type).toBe(NOTIFICATION_DATA_TYPE.CHARGE_FAILED);
+    expect(payload.trigger).toBeNull();
+  });
+
+  it('presentChargeFailedNotification uses custom detail message when provided', async () => {
+    const sub = makeSubscription();
+    await presentChargeFailedNotification(sub, 'Insufficient balance');
+
+    const [payload] = mockSchedule.mock.calls[0] as [{ content: { body: string } }];
+    expect(payload.content.body).toBe('Insufficient balance');
+  });
+
+  it('presentTransactionQueueNotification schedules with correct type', async () => {
+    await presentTransactionQueueNotification('Queue update', 'Your transaction was processed');
+
+    expect(mockSchedule).toHaveBeenCalledTimes(1);
+    const [payload] = mockSchedule.mock.calls[0] as [
+      { content: { title: string; body: string; data: { type: string } } },
+    ];
+    expect(payload.content.title).toBe('Queue update');
+    expect(payload.content.body).toBe('Your transaction was processed');
+    expect(payload.content.data.type).toBe(NOTIFICATION_DATA_TYPE.TRANSACTION_QUEUE);
+  });
+
+  it('syncRenewalReminders cancels existing renewal reminders before rescheduling', async () => {
+    const existingNotif = {
+      identifier: 'old-notif-1',
+      content: {
+        title: 'Old reminder',
+        body: '',
+        data: { type: NOTIFICATION_DATA_TYPE.RENEWAL_REMINDER },
+      },
+      trigger: null,
+    };
+    mockGetScheduled.mockResolvedValueOnce([existingNotif]);
+
+    const sub = makeSubscription({
+      nextBillingDate: new Date(Date.now() + 48 * 60 * 60 * 1000), // 2 days from now
+      notificationsEnabled: true,
+      isActive: true,
+    });
+
+    await syncRenewalReminders([sub]);
+
+    expect(mockCancel).toHaveBeenCalledWith('old-notif-1');
+  });
+
+  it('syncRenewalReminders does not schedule for inactive subscriptions', async () => {
+    mockGetScheduled.mockResolvedValueOnce([]);
+
+    const sub = makeSubscription({ isActive: false, notificationsEnabled: true });
+    await syncRenewalReminders([sub]);
+
+    expect(mockSchedule).not.toHaveBeenCalled();
+  });
+
+  it('syncRenewalReminders does not schedule when notificationsEnabled is false', async () => {
+    mockGetScheduled.mockResolvedValueOnce([]);
+
+    const sub = makeSubscription({
+      isActive: true,
+      notificationsEnabled: false,
+      nextBillingDate: new Date(Date.now() + 48 * 60 * 60 * 1000),
+    });
+    await syncRenewalReminders([sub]);
+
+    expect(mockSchedule).not.toHaveBeenCalled();
+  });
+
+  it('syncRenewalReminders schedules a reminder for an active sub with future billing date', async () => {
+    mockGetScheduled.mockResolvedValueOnce([]);
+
+    const sub = makeSubscription({
+      isActive: true,
+      notificationsEnabled: true,
+      billingCycle: BillingCycle.MONTHLY,
+      nextBillingDate: new Date(Date.now() + 48 * 60 * 60 * 1000), // 2 days out
+    });
+
+    await syncRenewalReminders([sub]);
+
+    expect(mockSchedule).toHaveBeenCalledTimes(1);
+    const [payload] = mockSchedule.mock.calls[0] as [{ content: { data: { type: string } } }];
+    expect(payload.content.data.type).toBe(NOTIFICATION_DATA_TYPE.RENEWAL_REMINDER);
+  });
+
+  it('notifications are skipped on unsupported platforms', async () => {
+    // Temporarily override Platform.OS
+    Object.defineProperty(Platform, 'OS', { value: 'web', configurable: true });
+
+    const sub = makeSubscription();
+    await presentChargeSuccessNotification(sub);
+
+    expect(mockSchedule).not.toHaveBeenCalled();
+
+    Object.defineProperty(Platform, 'OS', { value: 'ios', configurable: true });
+  });
+});

--- a/app/tests/integration/wallet-connection.integration.test.ts
+++ b/app/tests/integration/wallet-connection.integration.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Integration tests: wallet connection flow
+ *
+ * Verifies the walletStore connect/disconnect lifecycle, persistence,
+ * and crypto-stream management end-to-end.
+ */
+
+import { act } from 'react';
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useWalletStore } from '../../../src/store/walletStore';
+import { makeWallet, makeCryptoStream, resetIdCounter } from './factories';
+
+// ── In-memory AsyncStorage ────────────────────────────────────────────────────
+const mockMemoryStore = new Map<string, string>();
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: jest.fn((key: string, value: string) => {
+    mockMemoryStore.set(key, value);
+    return Promise.resolve();
+  }),
+  getItem: jest.fn((key: string) => Promise.resolve(mockMemoryStore.get(key) ?? null)),
+  removeItem: jest.fn((key: string) => {
+    mockMemoryStore.delete(key);
+    return Promise.resolve();
+  }),
+  clear: jest.fn(() => {
+    mockMemoryStore.clear();
+    return Promise.resolve();
+  }),
+}));
+
+const WALLET_KEY = '@subtrackr_wallet';
+
+function resetWalletStore() {
+  useWalletStore.setState({
+    wallet: null,
+    address: null,
+    network: null,
+    cryptoStreams: [],
+    isLoading: false,
+    error: null,
+  });
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  mockMemoryStore.clear();
+  (AsyncStorage.setItem as jest.Mock).mockClear();
+  (AsyncStorage.getItem as jest.Mock).mockClear();
+  (AsyncStorage.removeItem as jest.Mock).mockClear();
+  resetWalletStore();
+  resetIdCounter();
+});
+
+afterEach(() => {
+  jest.runAllTimers();
+  jest.useRealTimers();
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+describe('wallet connection integration', () => {
+  it('connectWallet persists wallet data to AsyncStorage', async () => {
+    await act(async () => {
+      await useWalletStore.getState().connectWallet();
+    });
+
+    expect(useWalletStore.getState().wallet).not.toBeNull();
+    expect(useWalletStore.getState().address).toBeTruthy();
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      WALLET_KEY,
+      expect.stringContaining(useWalletStore.getState().address!)
+    );
+  });
+
+  it('connectWallet restores wallet from AsyncStorage without writing again', async () => {
+    const wallet = makeWallet({ address: '0xRestoredAddress' });
+    mockMemoryStore.set(
+      WALLET_KEY,
+      JSON.stringify({ address: wallet.address, network: 'Polygon', wallet })
+    );
+
+    await act(async () => {
+      await useWalletStore.getState().connectWallet();
+    });
+
+    expect(useWalletStore.getState().address).toBe('0xRestoredAddress');
+    expect(useWalletStore.getState().network).toBe('Polygon');
+    expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+  });
+
+  it('disconnect clears state and removes wallet from AsyncStorage', async () => {
+    await act(async () => {
+      await useWalletStore.getState().connectWallet();
+    });
+
+    await act(async () => {
+      await useWalletStore.getState().disconnect();
+    });
+
+    const { wallet, address, network, cryptoStreams } = useWalletStore.getState();
+    expect(wallet).toBeNull();
+    expect(address).toBeNull();
+    expect(network).toBeNull();
+    expect(cryptoStreams).toHaveLength(0);
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith(WALLET_KEY);
+  });
+
+  it('connect → disconnect → reconnect restores a fresh wallet', async () => {
+    await act(async () => {
+      await useWalletStore.getState().connectWallet();
+    });
+    const firstAddress = useWalletStore.getState().address;
+
+    await act(async () => {
+      await useWalletStore.getState().disconnect();
+    });
+    expect(useWalletStore.getState().wallet).toBeNull();
+
+    await act(async () => {
+      await useWalletStore.getState().connectWallet();
+    });
+    expect(useWalletStore.getState().address).toBe(firstAddress);
+    expect(useWalletStore.getState().wallet).not.toBeNull();
+  });
+
+  it('disconnect sets error when AsyncStorage.removeItem throws', async () => {
+    await act(async () => {
+      await useWalletStore.getState().connectWallet();
+    });
+
+    (AsyncStorage.removeItem as jest.Mock).mockImplementationOnce(() =>
+      Promise.reject(new Error('Storage failure'))
+    );
+
+    await act(async () => {
+      await useWalletStore.getState().disconnect();
+    });
+
+    expect(useWalletStore.getState().error).toBeTruthy();
+  });
+
+  it('isLoading resets to false after connect and disconnect', async () => {
+    await act(async () => {
+      await useWalletStore.getState().connectWallet();
+    });
+    expect(useWalletStore.getState().isLoading).toBe(false);
+
+    await act(async () => {
+      await useWalletStore.getState().disconnect();
+    });
+    expect(useWalletStore.getState().isLoading).toBe(false);
+  });
+
+  it('createCryptoStream then cancelCryptoStream marks stream inactive', async () => {
+    jest.useRealTimers();
+
+    await act(async () => {
+      await useWalletStore.getState().createCryptoStream({
+        token: 'USDC',
+        amount: 25,
+        flowRate: '0.0005',
+        startDate: new Date('2026-04-01'),
+        protocol: 'superfluid',
+      });
+    });
+
+    const { cryptoStreams } = useWalletStore.getState();
+    expect(cryptoStreams).toHaveLength(1);
+    expect(cryptoStreams[0].isActive).toBe(true);
+
+    const streamId = cryptoStreams[0].id;
+
+    await act(async () => {
+      await useWalletStore.getState().cancelCryptoStream(streamId);
+    });
+
+    expect(useWalletStore.getState().cryptoStreams[0].isActive).toBe(false);
+    expect(useWalletStore.getState().isLoading).toBe(false);
+
+    jest.useFakeTimers();
+  }, 10_000);
+
+  it('seeded crypto stream state is preserved across store resets', () => {
+    const stream = makeCryptoStream({ token: 'ETHx', isActive: true });
+    useWalletStore.setState({ cryptoStreams: [stream] });
+
+    expect(useWalletStore.getState().cryptoStreams[0].token).toBe('ETHx');
+    expect(useWalletStore.getState().cryptoStreams[0].isActive).toBe(true);
+  });
+});

--- a/backend/tests/integration/api-endpoints.integration.test.ts
+++ b/backend/tests/integration/api-endpoints.integration.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Integration tests: API endpoints (monitoring & alerting service layer)
+ *
+ * Verifies that MonitoringService and AlertingService correctly process
+ * transaction events, evaluate alert rules, dispatch alerts, and produce
+ * dashboard snapshots — simulating the full API request/response cycle.
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { MonitoringService } from '../../../backend/services/monitoring';
+import { AlertingService, createDispatcher } from '../../../backend/services/alerting';
+import type { TransactionEvent, AlertRule, Alert } from '../../../backend/services/types';
+
+// ── Factories ─────────────────────────────────────────────────────────────────
+let _txCounter = 0;
+
+function makeTxEvent(overrides: Partial<TransactionEvent> = {}): TransactionEvent {
+  return {
+    id: `tx-${++_txCounter}`,
+    subscriptionId: `sub-${_txCounter}`,
+    amount: 9.99,
+    currency: 'USD',
+    status: 'success',
+    timestamp: Date.now(),
+    gasUsed: 21000,
+    ...overrides,
+  };
+}
+
+function makeAlert(overrides: Partial<Alert> = {}): Alert {
+  return {
+    id: `alert-${++_txCounter}`,
+    severity: 'warning',
+    title: 'Test Alert',
+    message: 'Something happened',
+    timestamp: Date.now(),
+    resolved: false,
+    ruleId: 'test-rule',
+    ...overrides,
+  };
+}
+
+function makeHighFailureRateRule(threshold = 0.3): AlertRule {
+  return {
+    id: 'high-failure-rate',
+    name: 'High failure rate',
+    severity: 'critical',
+    message: `Failure rate exceeded ${threshold * 100}%`,
+    evaluate: (metrics) => {
+      // metrics accumulates all historical entries; use the last value for this name
+      const latest = [...metrics].reverse().find((x) => x.name === 'failure_rate');
+      return latest !== undefined && latest.value > threshold;
+    },
+  };
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+describe('API endpoints integration', () => {
+  let monitoring: MonitoringService;
+  let alerting: AlertingService;
+
+  beforeEach(() => {
+    _txCounter = 0;
+    monitoring = new MonitoringService([]); // no default rules — full control in tests
+    alerting = new AlertingService([{ type: 'console' }]);
+  });
+
+  // ── MonitoringService ─────────────────────────────────────────────────────
+
+  it('records a transaction and reflects it in the dashboard', () => {
+    monitoring.recordTransaction(makeTxEvent({ status: 'success' }));
+    const dashboard = monitoring.getDashboard();
+
+    expect(dashboard.totalTransactions).toBe(1);
+    expect(dashboard.successRate).toBe(1);
+    expect(dashboard.failureCount).toBe(0);
+  });
+
+  it('calculates correct success rate with mixed outcomes', () => {
+    monitoring.recordTransaction(makeTxEvent({ status: 'success' }));
+    monitoring.recordTransaction(makeTxEvent({ status: 'success' }));
+    monitoring.recordTransaction(makeTxEvent({ status: 'failed' }));
+
+    const dashboard = monitoring.getDashboard();
+    expect(dashboard.totalTransactions).toBe(3);
+    expect(dashboard.failureCount).toBe(1);
+    expect(dashboard.successRate).toBeCloseTo(2 / 3, 5);
+  });
+
+  it('averages gas used across transactions', () => {
+    monitoring.recordTransaction(makeTxEvent({ gasUsed: 21000 }));
+    monitoring.recordTransaction(makeTxEvent({ gasUsed: 42000 }));
+
+    const dashboard = monitoring.getDashboard();
+    expect(dashboard.avgGasUsed).toBe(31500);
+  });
+
+  it('getDashboard returns zero/safe values when no data recorded', () => {
+    const dashboard = monitoring.getDashboard();
+    expect(dashboard.totalTransactions).toBe(0);
+    expect(dashboard.successRate).toBe(1); // no failures → 100%
+    expect(dashboard.failureCount).toBe(0);
+    expect(dashboard.avgGasUsed).toBe(0);
+  });
+
+  it('addRule fires an alert when threshold is breached', () => {
+    monitoring.addRule(makeHighFailureRateRule(0.1));
+
+    // 2 failures out of 2 = 100% failure rate → exceeds 10% threshold
+    monitoring.recordTransaction(makeTxEvent({ status: 'failed' }));
+    monitoring.recordTransaction(makeTxEvent({ status: 'failed' }));
+
+    const dashboard = monitoring.getDashboard();
+    expect(dashboard.activeAlerts.length).toBeGreaterThanOrEqual(1);
+    expect(dashboard.activeAlerts[0].ruleId).toBe('high-failure-rate');
+  });
+
+  it('resolveAlert removes alert from active list', () => {
+    monitoring.addRule(makeHighFailureRateRule(0.1));
+    monitoring.recordTransaction(makeTxEvent({ status: 'failed' }));
+
+    const before = monitoring.getDashboard().activeAlerts;
+    expect(before.length).toBeGreaterThanOrEqual(1);
+
+    monitoring.resolveAlert(before[0].id);
+    expect(monitoring.getActiveAlerts()).toHaveLength(0);
+  });
+
+  it('removeRule stops future alerts for that rule', () => {
+    monitoring.addRule(makeHighFailureRateRule(0.1));
+    monitoring.removeRule('high-failure-rate');
+
+    monitoring.recordTransaction(makeTxEvent({ status: 'failed' }));
+    monitoring.recordTransaction(makeTxEvent({ status: 'failed' }));
+
+    expect(monitoring.getDashboard().activeAlerts).toHaveLength(0);
+  });
+
+  it('recentMetrics includes failure_rate after recording transactions', () => {
+    monitoring.recordTransaction(makeTxEvent({ status: 'success' }));
+
+    const dashboard = monitoring.getDashboard();
+    const metric = dashboard.recentMetrics.find((m) => m.name === 'failure_rate');
+    expect(metric).toBeDefined();
+    expect(metric!.value).toBe(0);
+  });
+
+  // ── AlertingService ───────────────────────────────────────────────────────
+
+  it('dispatch sends alert to console channel without throwing', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const alert = makeAlert({ severity: 'critical', title: 'Critical issue' });
+
+    await alerting.dispatch(alert);
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Critical issue'));
+    consoleSpy.mockRestore();
+  });
+
+  it('dispatch is idempotent — same alert id dispatched only once', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const alert = makeAlert();
+
+    await alerting.dispatch(alert);
+    await alerting.dispatch(alert);
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    consoleSpy.mockRestore();
+  });
+
+  it('dispatchAll skips resolved alerts', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const active = makeAlert({ resolved: false });
+    const resolved = makeAlert({ resolved: true });
+
+    await alerting.dispatchAll([active, resolved]);
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    consoleSpy.mockRestore();
+  });
+
+  it('createDispatcher throws when webhookUrl is missing for slack channel', () => {
+    expect(() => createDispatcher({ type: 'slack' })).toThrow('webhookUrl required');
+  });
+
+  // ── Full pipeline: transactions → metrics → alert → dispatch ─────────────
+
+  it('full pipeline: high failure rate triggers and dispatches a critical alert', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      // Use a low threshold (0.1) so the first failed transaction (50% rate) triggers it
+      monitoring.addRule(makeHighFailureRateRule(0.1));
+
+      // 1 success + 1 failure = 50% failure rate → exceeds 10% threshold
+      monitoring.recordTransaction(makeTxEvent({ status: 'success' }));
+      monitoring.recordTransaction(makeTxEvent({ status: 'failed' }));
+
+      const { activeAlerts } = monitoring.getDashboard();
+      expect(activeAlerts.length).toBeGreaterThanOrEqual(1);
+      expect(activeAlerts[0].severity).toBe('critical');
+
+      // Use a fresh alerting instance to avoid any cross-test state
+      const freshAlerting = new AlertingService([{ type: 'console' }]);
+      await freshAlerting.dispatchAll(activeAlerts);
+
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('CRITICAL'));
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+});

--- a/docs/caching-strategy.md
+++ b/docs/caching-strategy.md
@@ -1,0 +1,147 @@
+# Caching Strategy
+
+SubTrackr uses a multi-layer cache with offline queue support to keep the app fast and functional without a network connection.
+
+## Architecture
+
+```
+Read path:   L1 (memory Map) → L2 (AsyncStorage) → store/network
+Write path:  L1 + L2 simultaneously (write-through)
+Offline:     mutations enqueued → flushed on reconnect
+```
+
+### Layers
+
+| Layer | Storage         | Lifetime         | Speed    |
+| ----- | --------------- | ---------------- | -------- |
+| L1    | In-memory `Map` | Process lifetime | ~0 ms    |
+| L2    | `AsyncStorage`  | App restarts     | ~5–20 ms |
+
+L2 entries are promoted to L1 on first read to avoid repeated disk access.
+
+## Files
+
+| File                                                | Purpose                                          |
+| --------------------------------------------------- | ------------------------------------------------ |
+| `src/services/cache/cacheService.ts`                | Core `CacheService` class + singleton            |
+| `src/hooks/useCachedSubscriptions.ts`               | React hook wrapping subscriptionStore with cache |
+| `src/services/cache/__tests__/cacheService.test.ts` | Unit tests                                       |
+
+## Usage
+
+### Basic read/write
+
+```ts
+import { cacheService } from '../services/cache/cacheService';
+
+// Write (5 min TTL, tagged for bulk invalidation)
+await cacheService.set('subscriptions:all', subs, {
+  ttl: 5 * 60_000,
+  tags: ['subscriptions'],
+});
+
+// Read (L1 → L2 → null)
+const cached = await cacheService.get<Subscription[]>('subscriptions:all');
+```
+
+### In a component
+
+```ts
+import { useCachedSubscriptions } from '../hooks/useCachedSubscriptions';
+
+function HomeScreen() {
+  const { subscriptions, fetchSubscriptions, prefetchSubscriptions } = useCachedSubscriptions();
+
+  useEffect(() => {
+    void fetchSubscriptions();
+  }, []);
+  // ...
+}
+```
+
+### Prefetch on navigation
+
+```ts
+// In a list item's onPress — prefetch before the screen mounts
+onPress={() => {
+  void prefetchSubscriptions();
+  navigation.navigate('SubscriptionDetail', { id });
+}}
+```
+
+## Cache Invalidation
+
+### TTL (time-based)
+
+Every entry has a TTL (default 60 s). Expired entries are evicted lazily on next read.
+
+```ts
+await cacheService.set(key, value, { ttl: 0 }); // never expires
+await cacheService.set(key, value, { ttl: 30_000 }); // 30 s
+```
+
+### Tag-based (bulk)
+
+Tag entries at write time; invalidate all at once:
+
+```ts
+await cacheService.set('subs:1', sub1, { tags: ['subscriptions'] });
+await cacheService.set('subs:2', sub2, { tags: ['subscriptions'] });
+
+// After a mutation:
+await cacheService.invalidateByTag('subscriptions');
+```
+
+### Manual
+
+```ts
+await cacheService.delete('specific-key');
+cacheService.clearMemory(); // L1 only
+await cacheService.clearAll(); // L1 + L2
+```
+
+## Offline Queue
+
+Mutations made while offline are enqueued and replayed when connectivity returns.
+
+```ts
+// Enqueue (called automatically by useCachedSubscriptions when offline)
+await cacheService.enqueueOfflineOperation('update:sub-1', updatedData, 'update:sub-1');
+
+// Flush on reconnect
+NetInfo.addEventListener((state) => {
+  if (state.isConnected) void syncOfflineQueue();
+});
+```
+
+### Conflict Resolution
+
+Two strategies, set at construction:
+
+| Strategy                    | Behaviour                                             |
+| --------------------------- | ----------------------------------------------------- |
+| `last-write-wins` (default) | Later enqueue for same `conflictKey` replaces earlier |
+| `first-write-wins`          | First enqueue wins; subsequent ones are discarded     |
+
+```ts
+import { CacheService } from '../services/cache/cacheService';
+const svc = new CacheService('first-write-wins');
+```
+
+## Metrics
+
+```ts
+const { hits, misses, evictions, offlineQueueDepth } = cacheService.getMetrics();
+cacheService.resetMetrics(); // zero counters (preserves queue depth)
+```
+
+Expose metrics in a debug screen or send to your monitoring service to track cache efficiency.
+
+## Constants
+
+| Constant          | Value                      | Description                      |
+| ----------------- | -------------------------- | -------------------------------- |
+| Default TTL       | 60 000 ms                  | Applied when `ttl` is omitted    |
+| Subscription TTL  | 300 000 ms                 | Used by `useCachedSubscriptions` |
+| Storage prefix    | `@subtrackr_cache:`        | AsyncStorage key namespace       |
+| Offline queue key | `@subtrackr_offline_queue` | Persisted queue storage key      |

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -1,0 +1,124 @@
+# Integration Test Documentation
+
+## Overview
+
+This document describes the integration test suite for SubTrackr, covering component interactions across the store, notification service, wallet connection, and backend API layers.
+
+## Test Structure
+
+```
+app/tests/integration/
+├── factories.ts                          # Shared test data factories
+├── contract-store.integration.test.ts   # Contract ↔ store interaction
+├── wallet-connection.integration.test.ts # Wallet connect/disconnect lifecycle
+└── notification-delivery.integration.test.ts # Notification scheduling & delivery
+
+backend/tests/integration/
+└── api-endpoints.integration.test.ts    # MonitoringService & AlertingService pipeline
+```
+
+## Running Integration Tests
+
+```bash
+# Run all tests (includes integration)
+npm test
+
+# Run only integration tests
+npx jest --testPathPattern="integration"
+
+# Run with coverage
+npx jest --coverage --testPathPattern="integration"
+```
+
+## Test Suites
+
+### 1. Contract–Store Interaction (`contract-store.integration.test.ts`)
+
+Verifies that `subscriptionStore` correctly integrates with `notificationService` on every mutation.
+
+| Test                                           | What it verifies                         |
+| ---------------------------------------------- | ---------------------------------------- |
+| addSubscription calls syncRenewalReminders     | Notification sync fires after add        |
+| updateSubscription propagates updated list     | Sync receives updated subscription data  |
+| deleteSubscription syncs after removal         | Deleted sub is absent from sync payload  |
+| recordBillingOutcome success                   | Charge-success notification is presented |
+| recordBillingOutcome failure                   | Charge-failed notification is presented  |
+| notificationsEnabled=false skips notifications | No notification when opted out           |
+| Stats after add → toggle → delete              | Stats stay consistent across lifecycle   |
+| categoryBreakdown accuracy                     | Breakdown reflects multiple categories   |
+
+### 2. Wallet Connection (`wallet-connection.integration.test.ts`)
+
+Verifies the `walletStore` connect/disconnect lifecycle and crypto-stream management.
+
+| Test                                     | What it verifies                          |
+| ---------------------------------------- | ----------------------------------------- |
+| connectWallet persists to AsyncStorage   | Wallet data written on first connect      |
+| connectWallet restores from AsyncStorage | Saved wallet loaded without re-writing    |
+| disconnect clears state and storage      | State nulled, AsyncStorage key removed    |
+| connect → disconnect → reconnect         | Full round-trip restores wallet           |
+| disconnect error handling                | Error state set when storage throws       |
+| isLoading resets after operations        | Loading flag always clears                |
+| createCryptoStream then cancel           | Stream created active, cancelled inactive |
+
+### 3. Notification Delivery (`notification-delivery.integration.test.ts`)
+
+Verifies `notificationService` schedules, cancels, and presents notifications correctly.
+
+| Test                                       | What it verifies                                   |
+| ------------------------------------------ | -------------------------------------------------- |
+| requestNotificationPermissions             | Returns GRANTED when already granted               |
+| presentChargeSuccessNotification           | Schedules immediate notification with correct type |
+| presentChargeFailedNotification            | Schedules immediate notification with correct type |
+| Custom detail message                      | Body uses provided detail string                   |
+| presentTransactionQueueNotification        | Correct title, body, and data type                 |
+| syncRenewalReminders cancels old reminders | Existing renewal reminders cancelled first         |
+| Inactive subscription skipped              | No schedule for inactive subs                      |
+| notificationsEnabled=false skipped         | No schedule when opted out                         |
+| Active sub with future date scheduled      | Reminder scheduled for eligible subs               |
+| Unsupported platform skipped               | No-op on web/unsupported platforms                 |
+
+### 4. API Endpoints (`backend/tests/integration/api-endpoints.integration.test.ts`)
+
+Verifies `MonitoringService` and `AlertingService` end-to-end pipeline.
+
+| Test                                | What it verifies                          |
+| ----------------------------------- | ----------------------------------------- |
+| recordTransaction → dashboard       | Transaction reflected in snapshot         |
+| Mixed outcomes success rate         | Correct ratio calculated                  |
+| Gas averaging                       | avgGasUsed computed correctly             |
+| Empty dashboard defaults            | Safe zero values when no data             |
+| addRule fires alert on breach       | Alert created when threshold exceeded     |
+| resolveAlert removes from active    | Resolved alerts excluded                  |
+| removeRule stops future alerts      | Removed rule no longer triggers           |
+| recentMetrics includes failure_rate | Metrics emitted after each transaction    |
+| dispatch idempotency                | Same alert dispatched only once           |
+| dispatchAll skips resolved          | Resolved alerts not re-dispatched         |
+| createDispatcher validation         | Throws when webhookUrl missing            |
+| Full pipeline                       | Transactions → metrics → alert → dispatch |
+
+## Test Data Factories (`factories.ts`)
+
+Factories provide minimal, deterministic fixtures. Use `resetIdCounter()` in `beforeEach` to ensure stable IDs across tests.
+
+```typescript
+import {
+  makeSubscriptionFormData,
+  makeSubscription,
+  makeWallet,
+  makeCryptoStream,
+  resetIdCounter,
+} from './factories';
+
+// Override any field
+const sub = makeSubscription({ price: 19.99, billingCycle: BillingCycle.YEARLY });
+const wallet = makeWallet({ address: '0xCustomAddress' });
+```
+
+## Design Principles
+
+- **No disk I/O**: AsyncStorage is replaced with an in-memory map.
+- **No real timers**: `jest.useFakeTimers()` controls async delays.
+- **No network calls**: All external services are mocked at the module boundary.
+- **Minimal fixtures**: Factories produce only the fields needed; tests override what they care about.
+- **Isolated state**: Each test resets store state in `beforeEach` to prevent cross-test pollution.

--- a/src/hooks/useCachedSubscriptions.ts
+++ b/src/hooks/useCachedSubscriptions.ts
@@ -1,0 +1,128 @@
+/**
+ * useCachedSubscriptions — thin hook that layers CacheService over subscriptionStore.
+ *
+ * - Reads from cache first; falls back to store on miss.
+ * - Writes through to both cache and store.
+ * - Enqueues mutations to the offline queue when offline.
+ * - Exposes prefetch for navigation hints.
+ */
+
+import { useCallback } from 'react';
+import NetInfo from '@react-native-community/netinfo';
+import { useSubscriptionStore } from '../store/subscriptionStore';
+import { cacheService } from '../services/cache/cacheService';
+import type { Subscription, SubscriptionFormData } from '../types/subscription';
+
+const SUBS_CACHE_KEY = 'subscriptions:all';
+const SUBS_TAG = 'subscriptions';
+const CACHE_TTL = 5 * 60 * 1000; // 5 min
+
+export function useCachedSubscriptions() {
+  const store = useSubscriptionStore();
+
+  const isOnline = useCallback(async (): Promise<boolean> => {
+    const state = await NetInfo.fetch();
+    return state.isConnected === true;
+  }, []);
+
+  /** Fetch subscriptions — cache-first, then store. */
+  const fetchSubscriptions = useCallback(async (): Promise<Subscription[]> => {
+    const cached = await cacheService.get<Subscription[]>(SUBS_CACHE_KEY);
+    if (cached) return cached;
+
+    await store.fetchSubscriptions();
+    const fresh = store.subscriptions;
+    await cacheService.set(SUBS_CACHE_KEY, fresh, { ttl: CACHE_TTL, tags: [SUBS_TAG] });
+    return fresh;
+  }, [store]);
+
+  /** Add — write-through; enqueue offline if no connectivity. */
+  const addSubscription = useCallback(
+    async (data: SubscriptionFormData): Promise<void> => {
+      const online = await isOnline();
+      if (!online) {
+        await cacheService.enqueueOfflineOperation(
+          `add:${data.name}:${Date.now()}`,
+          data,
+          `add:${data.name}`
+        );
+        return;
+      }
+      await store.addSubscription(data);
+      await cacheService.invalidateByTag(SUBS_TAG);
+    },
+    [store, isOnline]
+  );
+
+  /** Update — write-through; enqueue offline if no connectivity. */
+  const updateSubscription = useCallback(
+    async (id: string, data: Partial<Subscription>): Promise<void> => {
+      const online = await isOnline();
+      if (!online) {
+        await cacheService.enqueueOfflineOperation(`update:${id}`, data, `update:${id}`);
+        return;
+      }
+      await store.updateSubscription(id, data);
+      await cacheService.invalidateByTag(SUBS_TAG);
+    },
+    [store, isOnline]
+  );
+
+  /** Delete — write-through; enqueue offline if no connectivity. */
+  const deleteSubscription = useCallback(
+    async (id: string): Promise<void> => {
+      const online = await isOnline();
+      if (!online) {
+        await cacheService.enqueueOfflineOperation(`delete:${id}`, { id }, `delete:${id}`);
+        return;
+      }
+      await store.deleteSubscription(id);
+      await cacheService.invalidateByTag(SUBS_TAG);
+    },
+    [store, isOnline]
+  );
+
+  /** Flush offline queue when connectivity is restored. */
+  const syncOfflineQueue = useCallback(async (): Promise<void> => {
+    const ops = await cacheService.flushOfflineQueue();
+    for (const op of ops) {
+      const key = op.key;
+      if (key.startsWith('add:')) {
+        await store.addSubscription(op.value as SubscriptionFormData);
+      } else if (key.startsWith('update:')) {
+        const id = key.replace('update:', '');
+        await store.updateSubscription(id, op.value as Partial<Subscription>);
+      } else if (key.startsWith('delete:')) {
+        const id = (op.value as { id: string }).id;
+        await store.deleteSubscription(id);
+      }
+    }
+    await cacheService.invalidateByTag(SUBS_TAG);
+  }, [store]);
+
+  /** Prefetch subscriptions for a navigation transition. */
+  const prefetchSubscriptions = useCallback(async (): Promise<void> => {
+    await cacheService.prefetch(
+      SUBS_CACHE_KEY,
+      async () => {
+        await store.fetchSubscriptions();
+        return store.subscriptions;
+      },
+      { ttl: CACHE_TTL, tags: [SUBS_TAG] }
+    );
+  }, [store]);
+
+  return {
+    subscriptions: store.subscriptions,
+    stats: store.stats,
+    isLoading: store.isLoading,
+    error: store.error,
+    fetchSubscriptions,
+    addSubscription,
+    updateSubscription,
+    deleteSubscription,
+    syncOfflineQueue,
+    prefetchSubscriptions,
+    cacheMetrics: cacheService.getMetrics(),
+  };
+}

--- a/src/services/cache/__tests__/cacheService.test.ts
+++ b/src/services/cache/__tests__/cacheService.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Unit + integration tests for CacheService.
+ *
+ * Covers:
+ *  - L1 / L2 read/write/promotion
+ *  - TTL expiry and eviction
+ *  - Tag-based invalidation
+ *  - Offline queue: enqueue, conflict resolution, flush, hydrate
+ *  - Prefetch (hit / miss / loader error)
+ *  - Metrics
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { CacheService } from '../cacheService';
+
+// ── In-memory AsyncStorage ────────────────────────────────────────────────────
+const mockStore = new Map<string, string>();
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn((k: string) => Promise.resolve(mockStore.get(k) ?? null)),
+  setItem: jest.fn((k: string, v: string) => {
+    mockStore.set(k, v);
+    return Promise.resolve();
+  }),
+  removeItem: jest.fn((k: string) => {
+    mockStore.delete(k);
+    return Promise.resolve();
+  }),
+  getAllKeys: jest.fn(() => Promise.resolve([...mockStore.keys()])),
+  multiRemove: jest.fn((keys: string[]) => {
+    keys.forEach((k) => mockStore.delete(k));
+    return Promise.resolve();
+  }),
+}));
+
+beforeEach(() => {
+  mockStore.clear();
+  (AsyncStorage.getItem as jest.Mock).mockClear();
+  (AsyncStorage.setItem as jest.Mock).mockClear();
+  (AsyncStorage.removeItem as jest.Mock).mockClear();
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+describe('CacheService', () => {
+  // ── L1 / L2 read-write ────────────────────────────────────────────────────
+
+  it('set then get returns value from L1 without hitting AsyncStorage again', async () => {
+    const svc = new CacheService();
+    await svc.set('k1', { name: 'Netflix' }, { ttl: 60_000 });
+    (AsyncStorage.getItem as jest.Mock).mockClear();
+
+    const result = await svc.get<{ name: string }>('k1');
+    expect(result).toEqual({ name: 'Netflix' });
+    expect(AsyncStorage.getItem).not.toHaveBeenCalled();
+  });
+
+  it('get promotes L2 entry to L1 on first read', async () => {
+    const svc = new CacheService();
+    await svc.set('k2', 42, { ttl: 60_000 });
+
+    // Simulate cold L1 (new instance shares same AsyncStorage mock)
+    const svc2 = new CacheService();
+    const result = await svc2.get<number>('k2');
+    expect(result).toBe(42);
+  });
+
+  it('get returns null for unknown key', async () => {
+    const svc = new CacheService();
+    expect(await svc.get('missing')).toBeNull();
+  });
+
+  it('delete removes from both L1 and L2', async () => {
+    const svc = new CacheService();
+    await svc.set('k3', 'hello');
+    await svc.delete('k3');
+
+    expect(await svc.get('k3')).toBeNull();
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('@subtrackr_cache:k3');
+  });
+
+  // ── TTL / expiry ──────────────────────────────────────────────────────────
+
+  it('expired L1 entry is evicted and returns null', async () => {
+    const svc = new CacheService();
+    await svc.set('ttl-key', 'value', { ttl: 1 }); // 1 ms TTL
+
+    await new Promise((r) => setTimeout(r, 5)); // let it expire
+
+    const result = await svc.get('ttl-key');
+    expect(result).toBeNull();
+    expect(svc.getMetrics().evictions).toBeGreaterThanOrEqual(1);
+  });
+
+  it('ttl=0 entry never expires', async () => {
+    const svc = new CacheService();
+    await svc.set('forever', 'persistent', { ttl: 0 });
+
+    await new Promise((r) => setTimeout(r, 5));
+    expect(await svc.get('forever')).toBe('persistent');
+  });
+
+  // ── Tag invalidation ──────────────────────────────────────────────────────
+
+  it('invalidateByTag removes all entries with that tag', async () => {
+    const svc = new CacheService();
+    await svc.set('a', 1, { tags: ['subs'] });
+    await svc.set('b', 2, { tags: ['subs'] });
+    await svc.set('c', 3, { tags: ['wallet'] });
+
+    await svc.invalidateByTag('subs');
+
+    expect(await svc.get('a')).toBeNull();
+    expect(await svc.get('b')).toBeNull();
+    expect(await svc.get<number>('c')).toBe(3); // unaffected
+  });
+
+  it('clearMemory wipes L1 but L2 still serves reads', async () => {
+    const svc = new CacheService();
+    await svc.set('persist', 'yes', { ttl: 60_000 });
+    svc.clearMemory();
+
+    // L2 should still have it
+    const result = await svc.get('persist');
+    expect(result).toBe('yes');
+  });
+
+  it('clearAll wipes both layers', async () => {
+    const svc = new CacheService();
+    await svc.set('wipe-me', 'data');
+    await svc.clearAll();
+
+    expect(await svc.get('wipe-me')).toBeNull();
+    expect(mockStore.size).toBe(0);
+  });
+
+  // ── Offline queue ─────────────────────────────────────────────────────────
+
+  it('enqueueOfflineOperation adds an operation to the queue', async () => {
+    const svc = new CacheService();
+    await svc.enqueueOfflineOperation('update:sub-1', { price: 9.99 });
+
+    expect(svc.getOfflineQueue()).toHaveLength(1);
+    expect(svc.getOfflineQueue()[0].key).toBe('update:sub-1');
+    expect(svc.getMetrics().offlineQueueDepth).toBe(1);
+  });
+
+  it('last-write-wins: second enqueue with same conflictKey replaces first', async () => {
+    const svc = new CacheService('last-write-wins');
+    await svc.enqueueOfflineOperation('update:sub-1', { price: 9.99 }, 'update:sub-1');
+    await svc.enqueueOfflineOperation('update:sub-1', { price: 14.99 }, 'update:sub-1');
+
+    const queue = svc.getOfflineQueue();
+    expect(queue).toHaveLength(1);
+    expect((queue[0].value as { price: number }).price).toBe(14.99);
+  });
+
+  it('first-write-wins: second enqueue with same conflictKey is discarded', async () => {
+    const svc = new CacheService('first-write-wins');
+    await svc.enqueueOfflineOperation('update:sub-1', { price: 9.99 }, 'update:sub-1');
+    await svc.enqueueOfflineOperation('update:sub-1', { price: 14.99 }, 'update:sub-1');
+
+    const queue = svc.getOfflineQueue();
+    expect(queue).toHaveLength(1);
+    expect((queue[0].value as { price: number }).price).toBe(9.99);
+  });
+
+  it('flushOfflineQueue applies operations to cache and clears the queue', async () => {
+    const svc = new CacheService();
+    await svc.enqueueOfflineOperation('sub:1', { name: 'Spotify' });
+    await svc.enqueueOfflineOperation('sub:2', { name: 'Netflix' });
+
+    const flushed = await svc.flushOfflineQueue();
+
+    expect(flushed).toHaveLength(2);
+    expect(svc.getOfflineQueue()).toHaveLength(0);
+    expect(svc.getMetrics().offlineQueueDepth).toBe(0);
+    expect(await svc.get('sub:1')).toEqual({ name: 'Spotify' });
+  });
+
+  it('hydrateOfflineQueue restores queue from AsyncStorage', async () => {
+    const svc = new CacheService();
+    await svc.enqueueOfflineOperation('op:1', { x: 1 });
+
+    // New instance — L1 is empty, queue is empty
+    const svc2 = new CacheService();
+    await svc2.hydrateOfflineQueue();
+
+    expect(svc2.getOfflineQueue()).toHaveLength(1);
+    expect(svc2.getOfflineQueue()[0].key).toBe('op:1');
+  });
+
+  // ── Prefetch ──────────────────────────────────────────────────────────────
+
+  it('prefetch calls loader and caches result on miss', async () => {
+    const svc = new CacheService();
+    const loader = jest.fn(async () => [1, 2, 3]);
+
+    await svc.prefetch('list', loader as () => Promise<number[]>);
+
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(await svc.get('list')).toEqual([1, 2, 3]);
+  });
+
+  it('prefetch skips loader when valid entry already cached', async () => {
+    const svc = new CacheService();
+    await svc.set('list', [1, 2, 3], { ttl: 60_000 });
+    const loader = jest.fn(async () => [4, 5, 6]);
+
+    await svc.prefetch('list', loader as () => Promise<number[]>);
+
+    expect(loader).not.toHaveBeenCalled();
+    expect(await svc.get('list')).toEqual([1, 2, 3]);
+  });
+
+  it('prefetch silently swallows loader errors', async () => {
+    const svc = new CacheService();
+    const loader = jest.fn(async () => {
+      throw new Error('network error');
+    });
+
+    await expect(svc.prefetch('fail', loader as () => Promise<never>)).resolves.toBeUndefined();
+    expect(await svc.get('fail')).toBeNull();
+  });
+
+  // ── Metrics ───────────────────────────────────────────────────────────────
+
+  it('metrics track hits and misses correctly', async () => {
+    const svc = new CacheService();
+    await svc.get('no-exist'); // miss
+    await svc.set('exists', 1);
+    await svc.get('exists'); // hit
+
+    const m = svc.getMetrics();
+    expect(m.hits).toBe(1);
+    expect(m.misses).toBe(1);
+  });
+
+  it('resetMetrics zeroes counters but preserves queue depth', async () => {
+    const svc = new CacheService();
+    await svc.get('x'); // miss
+    await svc.enqueueOfflineOperation('op', {});
+    svc.resetMetrics();
+
+    const m = svc.getMetrics();
+    expect(m.hits).toBe(0);
+    expect(m.misses).toBe(0);
+    expect(m.offlineQueueDepth).toBe(1); // preserved
+  });
+});

--- a/src/services/cache/cacheService.ts
+++ b/src/services/cache/cacheService.ts
@@ -1,0 +1,285 @@
+/**
+ * CacheService — multi-layer caching with offline queue and sync conflict resolution.
+ *
+ * Layers (read order):
+ *   L1: in-memory Map (fastest, process-lifetime)
+ *   L2: AsyncStorage (survives app restarts)
+ *
+ * Features:
+ *   - TTL-based invalidation per entry
+ *   - Tag-based bulk invalidation
+ *   - Offline operation queue with conflict resolution (last-write-wins by default)
+ *   - Prefetch API for navigation hints
+ *   - Cache metrics (hits, misses, evictions, queue depth)
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface CacheEntry<T> {
+  value: T;
+  expiresAt: number; // epoch ms; 0 = never
+  tags: string[];
+}
+
+export interface OfflineOperation {
+  id: string;
+  key: string;
+  value: unknown;
+  timestamp: number;
+  /** Conflict key: operations sharing the same key are deduplicated (last wins) */
+  conflictKey: string;
+}
+
+export interface CacheMetrics {
+  hits: number;
+  misses: number;
+  evictions: number;
+  offlineQueueDepth: number;
+}
+
+export interface CacheOptions {
+  /** TTL in milliseconds. 0 = never expires. Default: 60_000 */
+  ttl?: number;
+  /** Tags for bulk invalidation */
+  tags?: string[];
+}
+
+export type ConflictResolution = 'last-write-wins' | 'first-write-wins';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const STORAGE_PREFIX = '@subtrackr_cache:';
+const OFFLINE_QUEUE_KEY = '@subtrackr_offline_queue';
+const DEFAULT_TTL_MS = 60_000;
+
+// ── CacheService ──────────────────────────────────────────────────────────────
+
+export class CacheService {
+  private l1 = new Map<string, CacheEntry<unknown>>();
+  private offlineQueue: OfflineOperation[] = [];
+  private metrics: CacheMetrics = { hits: 0, misses: 0, evictions: 0, offlineQueueDepth: 0 };
+  private conflictResolution: ConflictResolution;
+
+  constructor(conflictResolution: ConflictResolution = 'last-write-wins') {
+    this.conflictResolution = conflictResolution;
+  }
+
+  // ── Read ──────────────────────────────────────────────────────────────────
+
+  async get<T>(key: string): Promise<T | null> {
+    // L1
+    const l1Entry = this.l1.get(key) as CacheEntry<T> | undefined;
+    if (l1Entry) {
+      if (this._isExpired(l1Entry)) {
+        this.l1.delete(key);
+        this.metrics.evictions++;
+      } else {
+        this.metrics.hits++;
+        return l1Entry.value;
+      }
+    }
+
+    // L2
+    try {
+      const raw = await AsyncStorage.getItem(STORAGE_PREFIX + key);
+      if (raw) {
+        const entry = JSON.parse(raw) as CacheEntry<T>;
+        if (this._isExpired(entry)) {
+          await AsyncStorage.removeItem(STORAGE_PREFIX + key);
+          this.metrics.evictions++;
+        } else {
+          this.l1.set(key, entry as CacheEntry<unknown>); // promote to L1
+          this.metrics.hits++;
+          return entry.value;
+        }
+      }
+    } catch {
+      // storage read failure is non-fatal
+    }
+
+    this.metrics.misses++;
+    return null;
+  }
+
+  // ── Write ─────────────────────────────────────────────────────────────────
+
+  async set<T>(key: string, value: T, options: CacheOptions = {}): Promise<void> {
+    const ttl = options.ttl ?? DEFAULT_TTL_MS;
+    const entry: CacheEntry<T> = {
+      value,
+      expiresAt: ttl === 0 ? 0 : Date.now() + ttl,
+      tags: options.tags ?? [],
+    };
+
+    this.l1.set(key, entry as CacheEntry<unknown>);
+
+    try {
+      await AsyncStorage.setItem(STORAGE_PREFIX + key, JSON.stringify(entry));
+    } catch {
+      // L2 write failure is non-fatal; L1 still serves reads
+    }
+  }
+
+  // ── Delete ────────────────────────────────────────────────────────────────
+
+  async delete(key: string): Promise<void> {
+    this.l1.delete(key);
+    try {
+      await AsyncStorage.removeItem(STORAGE_PREFIX + key);
+    } catch {
+      // non-fatal
+    }
+  }
+
+  // ── Invalidation ──────────────────────────────────────────────────────────
+
+  /** Invalidate all entries carrying the given tag. */
+  async invalidateByTag(tag: string): Promise<void> {
+    const keysToDelete: string[] = [];
+
+    for (const [key, entry] of this.l1.entries()) {
+      if (entry.tags.includes(tag)) keysToDelete.push(key);
+    }
+
+    for (const key of keysToDelete) {
+      this.l1.delete(key);
+      this.metrics.evictions++;
+      try {
+        await AsyncStorage.removeItem(STORAGE_PREFIX + key);
+      } catch {
+        // non-fatal
+      }
+    }
+  }
+
+  /** Clear all L1 entries (L2 untouched — survives for offline reads). */
+  clearMemory(): void {
+    this.metrics.evictions += this.l1.size;
+    this.l1.clear();
+  }
+
+  /** Full wipe of both layers. */
+  async clearAll(): Promise<void> {
+    this.clearMemory();
+    try {
+      const keys = await AsyncStorage.getAllKeys();
+      const cacheKeys = keys.filter((k) => k.startsWith(STORAGE_PREFIX));
+      if (cacheKeys.length) await AsyncStorage.multiRemove(cacheKeys);
+    } catch {
+      // non-fatal
+    }
+  }
+
+  // ── Offline queue ─────────────────────────────────────────────────────────
+
+  /**
+   * Enqueue an operation to be replayed when connectivity is restored.
+   * Conflict resolution is applied immediately on enqueue.
+   */
+  async enqueueOfflineOperation(key: string, value: unknown, conflictKey?: string): Promise<void> {
+    const op: OfflineOperation = {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+      key,
+      value,
+      timestamp: Date.now(),
+      conflictKey: conflictKey ?? key,
+    };
+
+    const existing = this.offlineQueue.findIndex((o) => o.conflictKey === op.conflictKey);
+
+    if (existing !== -1) {
+      if (this.conflictResolution === 'last-write-wins') {
+        this.offlineQueue[existing] = op; // replace
+      }
+      // first-write-wins: discard new op (do nothing)
+    } else {
+      this.offlineQueue.push(op);
+    }
+
+    this.metrics.offlineQueueDepth = this.offlineQueue.length;
+    await this._persistQueue();
+  }
+
+  /** Drain the offline queue, applying each operation to the cache. */
+  async flushOfflineQueue(): Promise<OfflineOperation[]> {
+    const flushed = [...this.offlineQueue];
+    for (const op of flushed) {
+      await this.set(op.key, op.value, { ttl: DEFAULT_TTL_MS });
+    }
+    this.offlineQueue = [];
+    this.metrics.offlineQueueDepth = 0;
+    await this._persistQueue();
+    return flushed;
+  }
+
+  /** Restore the offline queue from AsyncStorage (call on app start). */
+  async hydrateOfflineQueue(): Promise<void> {
+    try {
+      const raw = await AsyncStorage.getItem(OFFLINE_QUEUE_KEY);
+      if (raw) this.offlineQueue = JSON.parse(raw) as OfflineOperation[];
+      this.metrics.offlineQueueDepth = this.offlineQueue.length;
+    } catch {
+      // non-fatal
+    }
+  }
+
+  getOfflineQueue(): OfflineOperation[] {
+    return [...this.offlineQueue];
+  }
+
+  // ── Prefetch ──────────────────────────────────────────────────────────────
+
+  /**
+   * Prefetch a value into cache using the provided loader.
+   * No-ops if a valid entry already exists.
+   */
+  async prefetch<T>(
+    key: string,
+    loader: () => Promise<T>,
+    options: CacheOptions = {}
+  ): Promise<void> {
+    const existing = await this.get<T>(key);
+    if (existing !== null) return;
+    try {
+      const value = await loader();
+      await this.set(key, value, options);
+    } catch {
+      // prefetch failure is silent — cache miss will trigger a fresh load
+    }
+  }
+
+  // ── Metrics ───────────────────────────────────────────────────────────────
+
+  getMetrics(): CacheMetrics {
+    return { ...this.metrics };
+  }
+
+  resetMetrics(): void {
+    this.metrics = {
+      hits: 0,
+      misses: 0,
+      evictions: 0,
+      offlineQueueDepth: this.offlineQueue.length,
+    };
+  }
+
+  // ── Internal ──────────────────────────────────────────────────────────────
+
+  private _isExpired(entry: CacheEntry<unknown>): boolean {
+    return entry.expiresAt !== 0 && Date.now() > entry.expiresAt;
+  }
+
+  private async _persistQueue(): Promise<void> {
+    try {
+      await AsyncStorage.setItem(OFFLINE_QUEUE_KEY, JSON.stringify(this.offlineQueue));
+    } catch {
+      // non-fatal
+    }
+  }
+}
+
+// ── Singleton ─────────────────────────────────────────────────────────────────
+
+export const cacheService = new CacheService();


### PR DESCRIPTION
## Summary

Implements a comprehensive multi-layer caching system with offline support as required by issue #225.

## Changes

### Core cache service
- `src/services/cache/cacheService.ts` — `CacheService` class + singleton export

### React integration
- `src/hooks/useCachedSubscriptions.ts` — drop-in hook wrapping `subscriptionStore` with cache

### Tests
- `src/services/cache/__tests__/cacheService.test.ts` — 19 tests, all passing

### Documentation
- `docs/caching-strategy.md` — full caching strategy documentation

## Acceptance Criteria

- [x] Multi-layer caching (L1 memory Map + L2 AsyncStorage)
- [x] Cache invalidation strategies (TTL-based, tag-based, manual)
- [x] Offline queue for operations (enqueue → flush on reconnect)
- [x] Sync conflict resolution (last-write-wins / first-write-wins)
- [x] Prefetching for navigation (`prefetch(key, loader)` + `prefetchSubscriptions()`)
- [x] Cache metrics monitoring (hits, misses, evictions, queue depth)
- [x] Caching strategy documented

## Test Results

19/19 tests passing ✅

Closes #225