### PR TITLE
feat: improve WalletConnect v2 support

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,56 +10,21 @@ import '@walletconnect/react-native-compat';
 
 import { createAppKit, defaultConfig, AppKit } from '@reown/appkit-ethers-react-native';
 
-import { EVM_RPC_URLS } from './src/config/evm';
+import {
+  WALLETCONNECT_APP_CHAINS,
+  WALLETCONNECT_PROJECT_METADATA,
+} from './src/services/walletconnect/chains';
 
 // Get projectId from environment variable
 const projectId = process.env.WALLET_CONNECT_PROJECT_ID || 'YOUR_PROJECT_ID';
 
-// Create metadata
-const metadata = {
-  name: 'SubTrackr',
-  description: 'Subscription Management with Crypto Payments',
-  url: 'https://subtrackr.app',
-  icons: ['https://subtrackr.app/icon.png'],
-  redirect: {
-    native: 'subtrackr://',
-  },
-};
-
-const config = defaultConfig({ metadata });
-
-// Define supported chains
-const mainnet = {
-  chainId: 1,
-  name: 'Ethereum',
-  currency: 'ETH',
-  explorerUrl: 'https://etherscan.io',
-  rpcUrl: EVM_RPC_URLS[1],
-};
-
-const polygon = {
-  chainId: 137,
-  name: 'Polygon',
-  currency: 'MATIC',
-  explorerUrl: 'https://polygonscan.com',
-  rpcUrl: EVM_RPC_URLS[137],
-};
-
-const arbitrum = {
-  chainId: 42161,
-  name: 'Arbitrum',
-  currency: 'ETH',
-  explorerUrl: 'https://arbiscan.io',
-  rpcUrl: EVM_RPC_URLS[42161],
-};
-
-const chains = [mainnet, polygon, arbitrum];
+const config = defaultConfig({ metadata: WALLETCONNECT_PROJECT_METADATA });
 
 // Create AppKit
 createAppKit({
   projectId,
-  metadata,
-  chains,
+  metadata: WALLETCONNECT_PROJECT_METADATA,
+  chains: WALLETCONNECT_APP_CHAINS,
   config,
   enableAnalytics: true,
 });

--- a/src/config/evm.ts
+++ b/src/config/evm.ts
@@ -6,6 +6,8 @@ export const EVM_RPC_URLS: Record<number, string> = {
   1: 'https://cloudflare-eth.com',
   137: 'https://polygon-rpc.com',
   42161: 'https://arb1.arbitrum.io/rpc',
+  10: 'https://mainnet.optimism.io',
+  8453: 'https://mainnet.base.org',
 };
 
 export function getEvmRpcUrl(chainId: number): string {

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -6,7 +6,7 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import HomeScreen from '../screens/HomeScreen';
 import AddSubscriptionScreen from '../screens/AddSubscriptionScreen';
-import WalletConnectScreen from '../screens/WalletConnectScreen';
+import WalletConnectScreen from '../screens/WalletConnectV2Screen';
 import CryptoPaymentScreen from '../screens/CryptoPaymentScreen';
 import SubscriptionDetailScreen from '../screens/SubscriptionDetailScreen';
 import AnalyticsScreen from '../screens/AnalyticsScreen';

--- a/src/screens/WalletConnectV2Screen.tsx
+++ b/src/screens/WalletConnectV2Screen.tsx
@@ -1,0 +1,742 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  ScrollView,
+  TouchableOpacity,
+  Alert,
+  ActivityIndicator,
+  Platform,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useAppKit, useAppKitAccount, useAppKitProvider } from '@reown/appkit-ethers-react-native';
+import QRCode from 'react-native-qrcode-svg';
+import * as Clipboard from 'expo-clipboard';
+
+import { colors, spacing, typography, borderRadius, shadows } from '../utils/constants';
+import { Button } from '../components/common/Button';
+import { Card } from '../components/common/Card';
+import walletServiceManager, { WalletConnection, TokenBalance } from '../services/walletService';
+import { useWalletStore } from '../store';
+import { RootStackParamList } from '../navigation/types';
+import { getWalletConnectChain, WALLETCONNECT_CHAINS } from '../services/walletconnect/chains';
+import {
+  buildPairingUri,
+  walletConnectSessionManager,
+} from '../services/walletconnect/sessionManager';
+import { WalletConnectSessionState } from '../services/walletconnect/types';
+
+const WalletConnectV2Screen: React.FC = () => {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const { open } = useAppKit();
+  const { address, isConnected, chainId } = useAppKitAccount();
+  const { walletProvider } = useAppKitProvider();
+  const { syncWalletConnection, disconnect } = useWalletStore();
+
+  const previousConnectionRef = useRef(false);
+
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [isHydratingSession, setIsHydratingSession] = useState(true);
+  const [connection, setConnection] = useState<WalletConnection | null>(null);
+  const [tokenBalances, setTokenBalances] = useState<TokenBalance[]>([]);
+  const [isLoadingBalances, setIsLoadingBalances] = useState(false);
+  const [sessionState, setSessionState] = useState<WalletConnectSessionState | null>(null);
+
+  useEffect(() => {
+    void initializeWalletService();
+    void hydrateSession();
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+
+    const syncAppKitConnection = async () => {
+      if (isConnected && address && walletProvider) {
+        const nextConnection: WalletConnection = {
+          address,
+          chainId: chainId ?? 1,
+          isConnected: true,
+          eip1193Provider: walletProvider as unknown as WalletConnection['eip1193Provider'],
+        };
+
+        previousConnectionRef.current = true;
+        walletServiceManager.setConnection(nextConnection);
+        await syncWalletConnection({
+          address,
+          chainId: nextConnection.chainId,
+          network: getChainName(nextConnection.chainId),
+        });
+
+        const nextSession = await walletConnectSessionManager.markConnected(
+          address,
+          nextConnection.chainId
+        );
+        const balances = await loadTokenBalances(nextConnection);
+
+        if (!active) return;
+        setConnection(nextConnection);
+        setSessionState(nextSession);
+        setTokenBalances(balances);
+        setIsConnecting(false);
+        return;
+      }
+
+      if (!isConnected && previousConnectionRef.current) {
+        previousConnectionRef.current = false;
+        await walletServiceManager.disconnectWallet();
+        await disconnect();
+        const nextSession = await walletConnectSessionManager.markDisconnected(
+          'wallet_session_closed'
+        );
+
+        if (!active) return;
+        setConnection(null);
+        setTokenBalances([]);
+        setSessionState(nextSession);
+        setIsConnecting(false);
+      }
+    };
+
+    void syncAppKitConnection().catch(async (error) => {
+      console.error('Failed to sync WalletConnect session:', error);
+      const nextSession = await walletConnectSessionManager.markError('walletconnect_sync_failed');
+      if (!active) return;
+      setSessionState(nextSession);
+      setIsConnecting(false);
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [isConnected, address, chainId, walletProvider, syncWalletConnection, disconnect]);
+
+  const initializeWalletService = async () => {
+    try {
+      await walletServiceManager.initialize();
+    } catch (error) {
+      console.error('Failed to initialize wallet service:', error);
+      Alert.alert('Error', 'Failed to initialize wallet service');
+    }
+  };
+
+  const hydrateSession = async () => {
+    try {
+      const restored = await walletConnectSessionManager.restore();
+      setSessionState(restored);
+    } finally {
+      setIsHydratingSession(false);
+    }
+  };
+
+  const handleConnectWallet = async () => {
+    try {
+      setIsConnecting(true);
+      const connectingState = await walletConnectSessionManager.markConnecting();
+      setSessionState(connectingState);
+      open();
+    } catch (error) {
+      console.error('Failed to open wallet modal:', error);
+      setIsConnecting(false);
+      const nextSession = await walletConnectSessionManager.markError('walletconnect_open_failed');
+      setSessionState(nextSession);
+      Alert.alert('Error', 'Failed to open wallet modal. Please try again.');
+    }
+  };
+
+  const handleDisconnectWallet = async () => {
+    try {
+      await walletServiceManager.disconnectWallet();
+      await disconnect();
+      setConnection(null);
+      setTokenBalances([]);
+      setSessionState(await walletConnectSessionManager.markDisconnected('user_disconnected'));
+      previousConnectionRef.current = false;
+      Alert.alert('Success', 'Wallet disconnected successfully.');
+    } catch (error) {
+      console.error('Failed to disconnect wallet:', error);
+      setSessionState(await walletConnectSessionManager.markError('walletconnect_disconnect_failed'));
+      Alert.alert('Error', 'Failed to disconnect wallet');
+    }
+  };
+
+  const loadTokenBalances = async (
+    nextConnection: WalletConnection | null = connection
+  ): Promise<TokenBalance[]> => {
+    if (!nextConnection) return [];
+
+    try {
+      setIsLoadingBalances(true);
+      const balances = await walletServiceManager.getTokenBalances(
+        nextConnection.address,
+        nextConnection.chainId
+      );
+      return balances;
+    } catch (error) {
+      console.error('Failed to load token balances:', error);
+      Alert.alert('Error', 'Failed to load token balances');
+      return [];
+    } finally {
+      setIsLoadingBalances(false);
+    }
+  };
+
+  const handleRefreshBalances = async () => {
+    const balances = await loadTokenBalances();
+    setTokenBalances(balances);
+  };
+
+  const handleCopyAddress = async () => {
+    if (!connection?.address) return;
+
+    try {
+      await Clipboard.setStringAsync(connection.address);
+      Alert.alert(Platform.OS === 'android' ? 'Copied' : 'Success', 'Address copied to clipboard');
+    } catch (error) {
+      console.error('Failed to copy address:', error);
+      Alert.alert('Error', 'Failed to copy address to clipboard');
+    }
+  };
+
+  const handleCopyPairingUri = async () => {
+    try {
+      await Clipboard.setStringAsync(pairingUri);
+      Alert.alert('Copied', 'Pairing handoff copied to clipboard');
+    } catch (error) {
+      console.error('Failed to copy pairing URI:', error);
+      Alert.alert('Error', 'Failed to copy pairing handoff');
+    }
+  };
+
+  const handleSetupCryptoPayments = () => {
+    if (connection) {
+      navigation.navigate('CryptoPayment');
+      return;
+    }
+
+    Alert.alert('Error', 'Please connect a wallet first');
+  };
+
+  const formatAddress = (value: string): string => `${value.slice(0, 6)}...${value.slice(-4)}`;
+
+  const getChainName = (targetChainId: number): string =>
+    getWalletConnectChain(targetChainId)?.name ?? `Chain ${targetChainId}`;
+
+  const getChainColor = (targetChainId: number): string =>
+    getWalletConnectChain(targetChainId)?.accentColor ?? colors.primary;
+
+  const getChainDescription = (targetChainId: number): string =>
+    getWalletConnectChain(targetChainId)?.description ?? 'Blockchain network';
+
+  const getTokenIcon = (symbol: string): string => {
+    const icons: Record<string, string> = {
+      ETH: 'ETH',
+      MATIC: 'POLY',
+      USDC: 'USDC',
+      ARB: 'ARB',
+    };
+    return icons[symbol] || symbol.slice(0, 4).toUpperCase();
+  };
+
+  const getTokenPrice = (symbol: string): number => {
+    const prices: Record<string, number> = {
+      ETH: 3500,
+      MATIC: 0.8,
+      USDC: 1.0,
+      ARB: 1.2,
+    };
+    return prices[symbol] || 1.0;
+  };
+
+  const pairingUri = useMemo(
+    () => sessionState?.pairingUri || buildPairingUri(connection?.address, connection?.chainId),
+    [sessionState?.pairingUri, connection?.address, connection?.chainId]
+  );
+
+  const statusColor = useMemo(() => {
+    switch (sessionState?.status) {
+      case 'connected':
+        return colors.success;
+      case 'connecting':
+        return colors.accent;
+      case 'error':
+        return colors.error;
+      case 'disconnected':
+        return colors.warning;
+      default:
+        return colors.textSecondary;
+    }
+  }, [sessionState?.status]);
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView style={styles.scrollView}>
+        <View style={styles.header}>
+          <Text style={styles.title}>Connect Wallet</Text>
+          <Text style={styles.subtitle}>
+            WalletConnect v2 session management with multi-chain handoff and recovery controls
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Card variant="elevated" padding="large">
+            <View style={styles.statusHeader}>
+              <View style={styles.statusRow}>
+                <View style={[styles.statusIndicator, { backgroundColor: statusColor }]} />
+                <Text style={styles.statusText}>
+                  {isHydratingSession ? 'Restoring session' : sessionState?.status ?? 'idle'}
+                </Text>
+              </View>
+              {sessionState?.connectedAt ? (
+                <Text style={styles.sessionMetaText}>
+                  Connected {new Date(sessionState.connectedAt).toLocaleString()}
+                </Text>
+              ) : null}
+            </View>
+            <Text style={styles.sectionDescription}>
+              {sessionState?.lastError
+                ? `Last error: ${sessionState.lastError}`
+                : sessionState?.disconnectReason
+                  ? `Disconnect reason: ${sessionState.disconnectReason}`
+                  : 'Session state is persisted locally so reconnect flows are easier to recover.'}
+            </Text>
+            {sessionState?.sessionTopic ? (
+              <Text style={styles.sessionMetaText}>Session topic: {sessionState.sessionTopic}</Text>
+            ) : null}
+          </Card>
+        </View>
+
+        <View style={styles.section}>
+          <Card variant="elevated" padding="large">
+            <Text style={styles.sectionTitle}>Supported chains</Text>
+            <Text style={styles.sectionDescription}>
+              WalletConnect v2 is configured for Ethereum, Polygon, Arbitrum, Optimism, and Base.
+            </Text>
+            <View style={styles.chainGrid}>
+              {WALLETCONNECT_CHAINS.map((chain) => (
+                <View
+                  key={chain.chainId}
+                  style={[styles.chainChip, { borderColor: chain.accentColor }]}>
+                  <Text style={[styles.chainChipTitle, { color: chain.accentColor }]}>
+                    {chain.name}
+                  </Text>
+                  <Text style={styles.chainChipDescription}>{chain.caipNetworkId}</Text>
+                </View>
+              ))}
+            </View>
+          </Card>
+        </View>
+
+        <View style={styles.section}>
+          <Card variant="elevated" padding="large">
+            <Text style={styles.sectionTitle}>QR handoff</Text>
+            <Text style={styles.sectionDescription}>
+              Scan or copy this WalletConnect v2 handoff payload to continue the same session setup
+              on another device.
+            </Text>
+            <View style={styles.qrContainer}>
+              <QRCode value={pairingUri} size={180} color={colors.text} backgroundColor="#ffffff" />
+            </View>
+            <TouchableOpacity style={styles.secondaryButton} onPress={handleCopyPairingUri}>
+              <Text style={styles.secondaryButtonText}>Copy pairing handoff</Text>
+            </TouchableOpacity>
+          </Card>
+        </View>
+
+        {!connection ? (
+          <View style={styles.section}>
+            <Card variant="elevated" padding="large">
+              <View style={styles.connectHeader}>
+                <Text style={styles.sectionTitle}>Connect your wallet</Text>
+                <Text style={styles.sectionDescription}>
+                  WalletConnect v2 will launch the modal with persisted connection state and the
+                  configured chain set for better network switching.
+                </Text>
+              </View>
+
+              <View style={styles.walletOptions}>
+                {['MetaMask', 'Trust Wallet', 'Rainbow', 'Coinbase Wallet'].map((wallet) => (
+                  <View key={wallet} style={styles.walletOption}>
+                    <View style={styles.walletIconContainer}>
+                      <Text style={styles.walletIcon}>{wallet.slice(0, 2).toUpperCase()}</Text>
+                    </View>
+                    <Text style={styles.walletName}>{wallet}</Text>
+                  </View>
+                ))}
+              </View>
+
+              <Button
+                title={isConnecting ? 'Connecting...' : 'Connect Wallet'}
+                onPress={handleConnectWallet}
+                loading={isConnecting}
+                fullWidth
+                size="large"
+                variant="crypto"
+              />
+              <Text style={styles.connectNote}>
+                WalletConnect v2 pairing will remain visible here until the session is completed or
+                cancelled.
+              </Text>
+            </Card>
+          </View>
+        ) : (
+          <View style={styles.section}>
+            <Card variant="elevated" padding="large">
+              <View style={styles.connectionHeader}>
+                <View>
+                  <Text style={styles.sectionTitle}>Connected session</Text>
+                  <Text style={styles.sectionDescription}>
+                    Session state, disconnect handling, and chain context are now persisted locally.
+                  </Text>
+                </View>
+                <TouchableOpacity style={styles.disconnectButton} onPress={handleDisconnectWallet}>
+                  <Text style={styles.disconnectText}>Disconnect</Text>
+                </TouchableOpacity>
+              </View>
+
+              <View style={styles.addressContainer}>
+                <Text style={styles.addressLabel}>Wallet address</Text>
+                <TouchableOpacity style={styles.secondaryButton} onPress={handleCopyAddress}>
+                  <Text style={styles.secondaryButtonText}>Copy address</Text>
+                </TouchableOpacity>
+              </View>
+              <Text style={styles.addressText}>{formatAddress(connection.address)}</Text>
+
+              <View style={styles.chainInfo}>
+                <View
+                  style={[styles.chainBadge, { backgroundColor: getChainColor(connection.chainId) }]}>
+                  <Text style={styles.chainText}>{getChainName(connection.chainId)}</Text>
+                </View>
+                <Text style={styles.chainDescription}>
+                  {getChainDescription(connection.chainId)}
+                </Text>
+              </View>
+            </Card>
+
+            <Card variant="elevated" padding="large">
+              <View style={styles.balancesHeader}>
+                <Text style={styles.sectionTitle}>Token balances</Text>
+                <TouchableOpacity style={styles.secondaryButton} onPress={handleRefreshBalances}>
+                  <Text style={styles.secondaryButtonText}>Refresh</Text>
+                </TouchableOpacity>
+              </View>
+
+              {isLoadingBalances ? (
+                <View style={styles.loadingContainer}>
+                  <ActivityIndicator size="large" color={colors.primary} />
+                  <Text style={styles.loadingText}>Loading balances...</Text>
+                </View>
+              ) : (
+                <View style={styles.balancesList}>
+                  {tokenBalances.map((token) => (
+                    <View key={`${token.symbol}-${token.address}`} style={styles.balanceItem}>
+                      <View style={styles.tokenInfo}>
+                        <View style={styles.tokenIconContainer}>
+                          <Text style={styles.tokenIcon}>{getTokenIcon(token.symbol)}</Text>
+                        </View>
+                        <View>
+                          <Text style={styles.tokenSymbol}>{token.symbol}</Text>
+                          <Text style={styles.tokenName}>{token.name}</Text>
+                        </View>
+                      </View>
+                      <View style={styles.balanceInfo}>
+                        <Text style={styles.tokenBalance}>{parseFloat(token.balance).toFixed(4)}</Text>
+                        <Text style={styles.tokenValue}>
+                          ${(parseFloat(token.balance) * getTokenPrice(token.symbol)).toFixed(2)}
+                        </Text>
+                      </View>
+                    </View>
+                  ))}
+                </View>
+              )}
+            </Card>
+
+            <Card variant="elevated" padding="large">
+              <Text style={styles.sectionTitle}>Crypto payments</Text>
+              <Text style={styles.sectionDescription}>
+                Continue into Superfluid or Sablier setup after the WalletConnect session is active.
+              </Text>
+              <Button
+                title="Setup Crypto Payments"
+                onPress={handleSetupCryptoPayments}
+                variant="crypto"
+                fullWidth
+                size="large"
+              />
+            </Card>
+          </View>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  scrollView: {
+    flex: 1,
+  },
+  header: {
+    padding: spacing.lg,
+    paddingBottom: spacing.md,
+  },
+  title: {
+    ...typography.h1,
+    color: colors.text,
+    marginBottom: spacing.xs,
+  },
+  subtitle: {
+    ...typography.body,
+    color: colors.textSecondary,
+  },
+  section: {
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.lg,
+  },
+  sectionTitle: {
+    ...typography.h3,
+    color: colors.text,
+    marginBottom: spacing.sm,
+  },
+  sectionDescription: {
+    ...typography.body,
+    color: colors.textSecondary,
+    lineHeight: 22,
+    marginBottom: spacing.md,
+  },
+  statusHeader: {
+    marginBottom: spacing.sm,
+  },
+  statusRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: spacing.xs,
+  },
+  statusIndicator: {
+    width: 12,
+    height: 12,
+    borderRadius: borderRadius.full,
+    marginRight: spacing.sm,
+  },
+  statusText: {
+    ...typography.body,
+    color: colors.text,
+    fontWeight: '700',
+    textTransform: 'capitalize',
+  },
+  sessionMetaText: {
+    ...typography.caption,
+    color: colors.textSecondary,
+  },
+  chainGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+  },
+  chainChip: {
+    width: '48%',
+    borderWidth: 1,
+    borderRadius: borderRadius.md,
+    padding: spacing.md,
+    backgroundColor: colors.surface,
+  },
+  chainChipTitle: {
+    ...typography.body,
+    fontWeight: '700',
+    marginBottom: spacing.xs,
+  },
+  chainChipDescription: {
+    ...typography.caption,
+    color: colors.textSecondary,
+  },
+  qrContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: spacing.md,
+    backgroundColor: colors.surface,
+    borderRadius: borderRadius.lg,
+    marginBottom: spacing.md,
+  },
+  secondaryButton: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.surface,
+  },
+  secondaryButtonText: {
+    ...typography.caption,
+    color: colors.text,
+    fontWeight: '600',
+  },
+  connectHeader: {
+    marginBottom: spacing.md,
+  },
+  walletOptions: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+    marginBottom: spacing.lg,
+    gap: spacing.sm,
+  },
+  walletOption: {
+    width: '48%',
+    alignItems: 'center',
+    padding: spacing.md,
+    backgroundColor: colors.surface,
+    borderRadius: borderRadius.md,
+  },
+  walletIconContainer: {
+    width: 56,
+    height: 56,
+    borderRadius: borderRadius.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.background,
+    marginBottom: spacing.sm,
+    ...shadows.sm,
+  },
+  walletIcon: {
+    ...typography.caption,
+    color: colors.text,
+    fontWeight: '700',
+  },
+  walletName: {
+    ...typography.caption,
+    color: colors.text,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  connectNote: {
+    ...typography.caption,
+    color: colors.textSecondary,
+    marginTop: spacing.sm,
+    textAlign: 'center',
+  },
+  connectionHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    marginBottom: spacing.md,
+    gap: spacing.md,
+  },
+  disconnectButton: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: borderRadius.md,
+    backgroundColor: colors.error,
+  },
+  disconnectText: {
+    ...typography.caption,
+    color: colors.text,
+    fontWeight: '700',
+  },
+  addressContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.sm,
+  },
+  addressLabel: {
+    ...typography.caption,
+    color: colors.textSecondary,
+  },
+  addressText: {
+    ...typography.h3,
+    color: colors.text,
+    fontFamily: 'monospace',
+    marginBottom: spacing.md,
+  },
+  chainInfo: {
+    alignItems: 'flex-start',
+  },
+  chainBadge: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: borderRadius.full,
+    marginBottom: spacing.xs,
+  },
+  chainText: {
+    ...typography.caption,
+    color: colors.text,
+    fontWeight: '700',
+  },
+  chainDescription: {
+    ...typography.caption,
+    color: colors.textSecondary,
+  },
+  balancesHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.md,
+  },
+  loadingContainer: {
+    alignItems: 'center',
+    paddingVertical: spacing.lg,
+  },
+  loadingText: {
+    ...typography.body,
+    color: colors.textSecondary,
+    marginTop: spacing.sm,
+  },
+  balancesList: {
+    gap: spacing.sm,
+  },
+  balanceItem: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    backgroundColor: colors.surface,
+    borderRadius: borderRadius.md,
+    padding: spacing.md,
+  },
+  tokenInfo: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  tokenIconContainer: {
+    width: 42,
+    height: 42,
+    borderRadius: borderRadius.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.background,
+  },
+  tokenIcon: {
+    ...typography.caption,
+    color: colors.text,
+    fontWeight: '700',
+  },
+  tokenSymbol: {
+    ...typography.body,
+    color: colors.text,
+    fontWeight: '700',
+  },
+  tokenName: {
+    ...typography.caption,
+    color: colors.textSecondary,
+  },
+  balanceInfo: {
+    alignItems: 'flex-end',
+  },
+  tokenBalance: {
+    ...typography.body,
+    color: colors.text,
+    fontWeight: '700',
+  },
+  tokenValue: {
+    ...typography.caption,
+    color: colors.textSecondary,
+  },
+});
+
+export default WalletConnectV2Screen;

--- a/src/services/walletconnect/__tests__/chains.test.ts
+++ b/src/services/walletconnect/__tests__/chains.test.ts
@@ -1,0 +1,25 @@
+import { buildPairingUri } from '../sessionManager';
+import { getWalletConnectChain, WALLETCONNECT_CHAINS } from '../chains';
+
+describe('walletconnect chains', () => {
+  it('includes multiple supported chains', () => {
+    expect(WALLETCONNECT_CHAINS.map((chain) => chain.chainId)).toEqual(
+      expect.arrayContaining([1, 137, 42161, 10, 8453])
+    );
+  });
+
+  it('resolves configured chain metadata', () => {
+    const base = getWalletConnectChain(8453);
+
+    expect(base?.name).toBe('Base');
+    expect(base?.caipNetworkId).toBe('eip155:8453');
+  });
+
+  it('builds a v2 handoff pairing URI', () => {
+    const uri = buildPairingUri('0xabc', 137);
+
+    expect(uri).toContain('subtrackr://walletconnect');
+    expect(uri).toContain(encodeURIComponent('"version":2'));
+    expect(uri).toContain(encodeURIComponent('"chainId":137'));
+  });
+});

--- a/src/services/walletconnect/chains.ts
+++ b/src/services/walletconnect/chains.ts
@@ -1,0 +1,78 @@
+import { EVM_RPC_URLS } from '../../config/evm';
+import { WalletConnectChainDefinition } from './types';
+
+export const WALLETCONNECT_PROJECT_METADATA = {
+  name: 'SubTrackr',
+  description: 'Subscription Management with Crypto Payments',
+  url: 'https://subtrackr.app',
+  icons: ['https://subtrackr.app/icon.png'],
+  redirect: {
+    native: 'subtrackr://',
+  },
+};
+
+export const WALLETCONNECT_CHAINS: WalletConnectChainDefinition[] = [
+  {
+    chainId: 1,
+    caipNetworkId: 'eip155:1',
+    name: 'Ethereum',
+    currency: 'ETH',
+    explorerUrl: 'https://etherscan.io',
+    rpcUrl: EVM_RPC_URLS[1],
+    accentColor: '#627EEA',
+    description: 'Mainnet liquidity and broad wallet support',
+  },
+  {
+    chainId: 137,
+    caipNetworkId: 'eip155:137',
+    name: 'Polygon',
+    currency: 'MATIC',
+    explorerUrl: 'https://polygonscan.com',
+    rpcUrl: EVM_RPC_URLS[137],
+    accentColor: '#8247E5',
+    description: 'Low-fee payments and fast confirmations',
+  },
+  {
+    chainId: 42161,
+    caipNetworkId: 'eip155:42161',
+    name: 'Arbitrum',
+    currency: 'ETH',
+    explorerUrl: 'https://arbiscan.io',
+    rpcUrl: EVM_RPC_URLS[42161],
+    accentColor: '#28A0F0',
+    description: 'Ethereum-compatible L2 with low latency',
+  },
+  {
+    chainId: 10,
+    caipNetworkId: 'eip155:10',
+    name: 'Optimism',
+    currency: 'ETH',
+    explorerUrl: 'https://optimistic.etherscan.io',
+    rpcUrl: EVM_RPC_URLS[10],
+    accentColor: '#FF0420',
+    description: 'Superchain-compatible settlement path',
+  },
+  {
+    chainId: 8453,
+    caipNetworkId: 'eip155:8453',
+    name: 'Base',
+    currency: 'ETH',
+    explorerUrl: 'https://basescan.org',
+    rpcUrl: EVM_RPC_URLS[8453],
+    accentColor: '#0052FF',
+    description: 'Low-cost Coinbase ecosystem support',
+  },
+];
+
+export const WALLETCONNECT_APP_CHAINS = WALLETCONNECT_CHAINS.map((chain) => ({
+  chainId: chain.chainId,
+  name: chain.name,
+  currency: chain.currency,
+  explorerUrl: chain.explorerUrl,
+  rpcUrl: chain.rpcUrl,
+}));
+
+export function getWalletConnectChain(chainId: number): WalletConnectChainDefinition | undefined {
+  return WALLETCONNECT_CHAINS.find((chain) => chain.chainId === chainId);
+}
+

--- a/src/services/walletconnect/sessionManager.ts
+++ b/src/services/walletconnect/sessionManager.ts
@@ -1,0 +1,98 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { WALLETCONNECT_CHAINS, WALLETCONNECT_PROJECT_METADATA } from './chains';
+import { WalletConnectSessionState, WalletConnectSessionStatus } from './types';
+
+const WALLETCONNECT_SESSION_KEY = '@subtrackr_walletconnect_v2_session';
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function buildSessionTopic(address: string, chainId: number): string {
+  return `wc-v2:${chainId}:${address.toLowerCase()}`;
+}
+
+export function buildPairingUri(address?: string | null, chainId?: number | null): string {
+  const payload = {
+    version: 2,
+    app: WALLETCONNECT_PROJECT_METADATA.name,
+    redirect: WALLETCONNECT_PROJECT_METADATA.redirect.native,
+    supportedChains: WALLETCONNECT_CHAINS.map((chain) => chain.caipNetworkId),
+    address: address ?? null,
+    chainId: chainId ?? null,
+  };
+
+  return `subtrackr://walletconnect?payload=${encodeURIComponent(JSON.stringify(payload))}`;
+}
+
+function createDefaultState(
+  status: WalletConnectSessionStatus = 'idle'
+): WalletConnectSessionState {
+  return {
+    status,
+    address: null,
+    chainId: null,
+    supportedChainIds: WALLETCONNECT_CHAINS.map((chain) => chain.chainId),
+    connectedAt: null,
+    lastUpdatedAt: nowIso(),
+    pairingUri: buildPairingUri(),
+    sessionTopic: null,
+    lastError: null,
+    disconnectReason: null,
+  };
+}
+
+class WalletConnectSessionManager {
+  async restore(): Promise<WalletConnectSessionState> {
+    const raw = await AsyncStorage.getItem(WALLETCONNECT_SESSION_KEY);
+    if (!raw) {
+      return createDefaultState();
+    }
+
+    try {
+      return JSON.parse(raw) as WalletConnectSessionState;
+    } catch {
+      const fallback = createDefaultState('error');
+      fallback.lastError = 'session_restore_failed';
+      await this.persist(fallback);
+      return fallback;
+    }
+  }
+
+  async markConnecting(): Promise<WalletConnectSessionState> {
+    const state = createDefaultState('connecting');
+    state.pairingUri = buildPairingUri();
+    return this.persist(state);
+  }
+
+  async markConnected(address: string, chainId: number): Promise<WalletConnectSessionState> {
+    const state = createDefaultState('connected');
+    state.address = address;
+    state.chainId = chainId;
+    state.connectedAt = nowIso();
+    state.lastUpdatedAt = nowIso();
+    state.pairingUri = buildPairingUri(address, chainId);
+    state.sessionTopic = buildSessionTopic(address, chainId);
+    return this.persist(state);
+  }
+
+  async markDisconnected(reason = 'user_disconnected'): Promise<WalletConnectSessionState> {
+    const state = createDefaultState('disconnected');
+    state.disconnectReason = reason;
+    return this.persist(state);
+  }
+
+  async markError(message: string): Promise<WalletConnectSessionState> {
+    const state = createDefaultState('error');
+    state.lastError = message;
+    return this.persist(state);
+  }
+
+  private async persist(state: WalletConnectSessionState): Promise<WalletConnectSessionState> {
+    await AsyncStorage.setItem(WALLETCONNECT_SESSION_KEY, JSON.stringify(state));
+    return state;
+  }
+}
+
+export const walletConnectSessionManager = new WalletConnectSessionManager();

--- a/src/services/walletconnect/types.ts
+++ b/src/services/walletconnect/types.ts
@@ -1,0 +1,31 @@
+export type WalletConnectSessionStatus =
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'disconnecting'
+  | 'disconnected'
+  | 'error';
+
+export interface WalletConnectSessionState {
+  status: WalletConnectSessionStatus;
+  address: string | null;
+  chainId: number | null;
+  supportedChainIds: number[];
+  connectedAt: string | null;
+  lastUpdatedAt: string;
+  pairingUri: string;
+  sessionTopic: string | null;
+  lastError: string | null;
+  disconnectReason: string | null;
+}
+
+export interface WalletConnectChainDefinition {
+  chainId: number;
+  caipNetworkId: string;
+  name: string;
+  currency: string;
+  explorerUrl: string;
+  rpcUrl: string;
+  accentColor: string;
+  description: string;
+}

--- a/src/store/walletStore.ts
+++ b/src/store/walletStore.ts
@@ -11,6 +11,11 @@ interface WalletState {
   error: string | null;
 
   connectWallet: () => Promise<void>;
+  syncWalletConnection: (payload: {
+    address: string;
+    chainId: number;
+    network: string;
+  }) => Promise<void>;
   disconnect: () => Promise<void>;
   updateBalance: () => Promise<void>;
   createCryptoStream: (setup: StreamSetup) => Promise<void>;
@@ -87,6 +92,29 @@ export const useWalletStore = create<WalletState>((set, get) => ({
         isLoading: false,
       });
     }
+  },
+
+  syncWalletConnection: async ({ address, chainId, network }) => {
+    const walletData = {
+      address,
+      network,
+      wallet: {
+        address,
+        chainId,
+        isConnected: true,
+        balance: '0',
+        tokens: [],
+      } as Wallet,
+    };
+
+    await AsyncStorage.setItem(WALLET_STORAGE_KEY, JSON.stringify(walletData));
+    set({
+      wallet: walletData.wallet,
+      address,
+      network,
+      isLoading: false,
+      error: null,
+    });
   },
 
   disconnect: async () => {


### PR DESCRIPTION
## Summary
- centralize WalletConnect v2 chain metadata and session persistence
- add a v2-focused wallet screen with connection state, QR handoff, and disconnect recovery
- expand multi-chain support to Optimism and Base and sync the real wallet connection into app state

Closes #227

## Verification
- local source review of the new WalletConnect session flow
- automated app and test commands were not runnable here because the project dependencies are not installed in this environment