### PR TITLE
feat: implement cancellation flow with retention offers (#388)

### DIFF
--- a/backend/services/retentionService.ts
+++ b/backend/services/retentionService.ts
@@ -1,0 +1,286 @@
+/**
+ * Retention Offer Service
+ * Generates segment-based retention offers, handles A/B testing,
+ * offer expiry, abuse prevention, and win-back campaign triggers.
+ */
+
+export type OfferType = 'discount' | 'pause' | 'feature_upgrade' | 'plan_change';
+
+export interface RetentionOffer {
+  id: string;
+  type: OfferType;
+  title: string;
+  description: string;
+  /** Discount percentage (0-100) for 'discount' type */
+  discountPercent?: number;
+  /** Number of months the discount applies */
+  discountMonths?: number;
+  /** Pause duration in days for 'pause' type */
+  pauseDays?: number;
+  /** Feature name for 'feature_upgrade' type */
+  featureName?: string;
+  /** Target plan id for 'plan_change' type */
+  targetPlanId?: string;
+  /** ISO timestamp when offer expires */
+  expiresAt: string;
+  /** A/B test variant identifier */
+  abVariant: 'A' | 'B';
+}
+
+export interface OfferResult {
+  accepted: boolean;
+  offerId: string;
+  acceptedAt?: string;
+}
+
+export interface CancellationRecord {
+  subscriptionId: string;
+  userId: string;
+  reason: string;
+  reasonCategory: CancellationReasonCategory;
+  offersPresented: string[];
+  offerAccepted: string | null;
+  cancelledAt: string;
+  coolOffEndsAt: string;
+}
+
+export type CancellationReasonCategory =
+  | 'price'
+  | 'competitor'
+  | 'technical'
+  | 'missing_feature'
+  | 'not_using'
+  | 'other';
+
+export interface UserSegmentContext {
+  userId: string;
+  subscriptionId: string;
+  subscriptionName: string;
+  monthlyPrice: number;
+  monthsActive: number;
+  totalMonthlySpend: number;
+  subscriptionTier: string;
+}
+
+// In-memory store for abuse prevention (in production, use Redis/DB)
+const offerAcceptanceLog = new Map<string, { count: number; lastAcceptedAt: number }>();
+const activeOffers = new Map<string, RetentionOffer>();
+const cancellationRecords: CancellationRecord[] = [];
+
+const COOL_OFF_DAYS = 3;
+const OFFER_EXPIRY_HOURS = 24;
+const MAX_OFFER_ACCEPTS_PER_YEAR = 2;
+
+/**
+ * Categorize a free-text cancellation reason into a structured category.
+ */
+export function categorizeCancellationReason(reason: string): CancellationReasonCategory {
+  const lower = reason.toLowerCase();
+  if (lower.includes('expensive') || lower.includes('price') || lower.includes('cost') || lower.includes('afford')) return 'price';
+  if (lower.includes('competitor') || lower.includes('switching') || lower.includes('alternative')) return 'competitor';
+  if (lower.includes('bug') || lower.includes('technical') || lower.includes('issue') || lower.includes('broken')) return 'technical';
+  if (lower.includes('feature') || lower.includes('missing') || lower.includes('need')) return 'missing_feature';
+  if (lower.includes('not using') || lower.includes("don't use") || lower.includes('no longer')) return 'not_using';
+  return 'other';
+}
+
+/**
+ * Check if a user has abused offers (accepted too many in the past year).
+ */
+function isOfferAbuser(userId: string): boolean {
+  const log = offerAcceptanceLog.get(userId);
+  if (!log) return false;
+  const oneYearAgo = Date.now() - 365 * 24 * 60 * 60 * 1000;
+  if (log.lastAcceptedAt < oneYearAgo) {
+    offerAcceptanceLog.delete(userId);
+    return false;
+  }
+  return log.count >= MAX_OFFER_ACCEPTS_PER_YEAR;
+}
+
+/**
+ * Determine A/B variant deterministically from userId.
+ */
+function getAbVariant(userId: string): 'A' | 'B' {
+  const sum = userId.split('').reduce((acc, c) => acc + c.charCodeAt(0), 0);
+  return sum % 2 === 0 ? 'A' : 'B';
+}
+
+/**
+ * Generate retention offers based on user segment context and cancellation reason.
+ * Returns up to 2 offers. Returns empty array if user is an offer abuser.
+ */
+export function generateRetentionOffers(
+  context: UserSegmentContext,
+  reasonCategory: CancellationReasonCategory
+): RetentionOffer[] {
+  if (isOfferAbuser(context.userId)) return [];
+
+  const expiresAt = new Date(Date.now() + OFFER_EXPIRY_HOURS * 60 * 60 * 1000).toISOString();
+  const variant = getAbVariant(context.userId);
+  const offers: RetentionOffer[] = [];
+
+  // Primary offer based on reason
+  switch (reasonCategory) {
+    case 'price': {
+      const discountPercent = context.subscriptionTier === 'premium' ? 30 : 20;
+      const discountMonths = variant === 'A' ? 2 : 3;
+      offers.push({
+        id: `offer-${Date.now()}-discount`,
+        type: 'discount',
+        title: `${discountPercent}% off for ${discountMonths} months`,
+        description: `Stay and save ${discountPercent}% on your next ${discountMonths} billing cycles.`,
+        discountPercent,
+        discountMonths,
+        expiresAt,
+        abVariant: variant,
+      });
+      break;
+    }
+    case 'not_using': {
+      offers.push({
+        id: `offer-${Date.now()}-pause`,
+        type: 'pause',
+        title: 'Pause your subscription',
+        description: 'Take a break for up to 30 days. No charges, no data loss.',
+        pauseDays: 30,
+        expiresAt,
+        abVariant: variant,
+      });
+      break;
+    }
+    case 'missing_feature': {
+      offers.push({
+        id: `offer-${Date.now()}-feature`,
+        type: 'feature_upgrade',
+        title: 'Unlock Premium Features Free',
+        description: 'Get 30 days of premium features at no extra cost.',
+        featureName: 'premium_trial',
+        expiresAt,
+        abVariant: variant,
+      });
+      break;
+    }
+    case 'competitor':
+    case 'technical':
+    case 'other':
+    default: {
+      const discountPercent = variant === 'A' ? 15 : 20;
+      offers.push({
+        id: `offer-${Date.now()}-discount`,
+        type: 'discount',
+        title: `${discountPercent}% loyalty discount`,
+        description: `We value your loyalty. Enjoy ${discountPercent}% off for 2 months.`,
+        discountPercent,
+        discountMonths: 2,
+        expiresAt,
+        abVariant: variant,
+      });
+      break;
+    }
+  }
+
+  // Secondary offer: plan downgrade for high-spend users
+  if (context.monthlyPrice > 20 && reasonCategory === 'price') {
+    offers.push({
+      id: `offer-${Date.now()}-plan`,
+      type: 'plan_change',
+      title: 'Switch to a lighter plan',
+      description: 'Keep core features at a lower price point.',
+      targetPlanId: 'basic',
+      expiresAt,
+      abVariant: variant,
+    });
+  }
+
+  // Cache active offers for expiry validation on accept
+  offers.forEach((o) => activeOffers.set(o.id, o));
+
+  return offers;
+}
+
+/**
+ * Accept a retention offer. Validates expiry and abuse prevention.
+ * Returns success/failure.
+ */
+export function acceptRetentionOffer(userId: string, offerId: string): OfferResult {
+  const offer = activeOffers.get(offerId);
+
+  if (!offer) {
+    return { accepted: false, offerId, acceptedAt: undefined };
+  }
+
+  if (new Date(offer.expiresAt) < new Date()) {
+    activeOffers.delete(offerId);
+    return { accepted: false, offerId };
+  }
+
+  if (isOfferAbuser(userId)) {
+    return { accepted: false, offerId };
+  }
+
+  // Record acceptance for abuse prevention
+  const existing = offerAcceptanceLog.get(userId);
+  offerAcceptanceLog.set(userId, {
+    count: (existing?.count ?? 0) + 1,
+    lastAcceptedAt: Date.now(),
+  });
+
+  activeOffers.delete(offerId);
+
+  return { accepted: true, offerId, acceptedAt: new Date().toISOString() };
+}
+
+/**
+ * Record a confirmed cancellation and trigger win-back campaign.
+ * Returns the cancellation record with cool-off end date.
+ */
+export function recordCancellation(
+  userId: string,
+  subscriptionId: string,
+  reason: string,
+  offersPresented: string[],
+  offerAccepted: string | null
+): CancellationRecord {
+  const reasonCategory = categorizeCancellationReason(reason);
+  const now = new Date();
+  const coolOffEndsAt = new Date(now.getTime() + COOL_OFF_DAYS * 24 * 60 * 60 * 1000).toISOString();
+
+  const record: CancellationRecord = {
+    subscriptionId,
+    userId,
+    reason,
+    reasonCategory,
+    offersPresented,
+    offerAccepted,
+    cancelledAt: now.toISOString(),
+    coolOffEndsAt,
+  };
+
+  cancellationRecords.push(record);
+
+  // Trigger win-back campaign (fire-and-forget)
+  triggerWinBackCampaign(record);
+
+  return record;
+}
+
+/**
+ * Trigger a win-back campaign after cancellation.
+ * In production this would enqueue a job or call a campaign service.
+ */
+function triggerWinBackCampaign(record: CancellationRecord): void {
+  // Schedule win-back email after cool-off period
+  const delayMs = new Date(record.coolOffEndsAt).getTime() - Date.now();
+  setTimeout(() => {
+    // In production: call campaignService.createWinBackCampaign(record)
+    console.log(`[RetentionService] Win-back campaign triggered for user ${record.userId}, sub ${record.subscriptionId}`);
+  }, Math.max(0, delayMs));
+}
+
+/**
+ * Get all cancellation records (for analytics/admin).
+ */
+export function getCancellationRecords(): CancellationRecord[] {
+  return [...cancellationRecords];
+}

--- a/src/screens/CancellationFlowScreen.tsx
+++ b/src/screens/CancellationFlowScreen.tsx
@@ -1,89 +1,226 @@
 import React, { useEffect } from 'react';
-import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  ActivityIndicator,
+  TouchableOpacity,
+} from 'react-native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { Button } from '../components/common/Button';
 import { Card } from '../components/common/Card';
-import { colors, spacing, typography } from '../utils/constants';
+import { colors, spacing, typography, borderRadius } from '../utils/constants';
 import { RootStackParamList } from '../navigation/types';
-import { useCancellationStore } from '../store/cancellationStore';
+import { useCancellationStore, CANCELLATION_REASONS } from '../store/cancellationStore';
+import { RetentionOffer } from '../../backend/services/retentionService';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'CancellationFlow'>;
 
-const CancellationFlowScreen: React.FC<Props> = ({ route, navigation }) => {
-  const { currentStep, setReason, setStep, acceptOffer, reset } = useCancellationStore();
+const OFFER_TYPE_ICONS: Record<string, string> = {
+  discount: '💰',
+  pause: '⏸️',
+  feature_upgrade: '⭐',
+  plan_change: '🔄',
+};
 
+const CancellationFlowScreen: React.FC<Props> = ({ route, navigation }) => {
   const { subscriptionId } = route.params;
+  const {
+    currentStep,
+    reason,
+    offers,
+    acceptedOfferId,
+    cancellationRecord,
+    isLoading,
+    error,
+    initFlow,
+    selectReason,
+    acceptOffer,
+    declineOffers,
+    confirmCancellation,
+    reset,
+  } = useCancellationStore();
 
   useEffect(() => {
+    initFlow(subscriptionId);
     return () => reset();
-  }, [reset]);
+  }, [subscriptionId]);
 
-  const handleFinalSuccess = () => {
-    navigation.popToTop();
+  const handleAcceptOffer = async (offerId: string) => {
+    await acceptOffer(offerId);
+  };
+
+  const handleConfirmCancellation = async () => {
+    await confirmCancellation();
+  };
+
+  const renderReasonStep = () => (
+    <View>
+      <Text style={styles.stepLabel}>Step 1 of 3</Text>
+      <Text style={styles.heading}>Why are you cancelling?</Text>
+      <Text style={styles.subheading}>Your feedback helps us improve.</Text>
+      {CANCELLATION_REASONS.map((r) => (
+        <TouchableOpacity
+          key={r}
+          style={[styles.reasonOption, reason === r && styles.reasonOptionSelected]}
+          onPress={() => selectReason(r)}
+          accessibilityRole="radio"
+          accessibilityState={{ selected: reason === r }}
+          accessibilityLabel={r}>
+          <Text style={[styles.reasonText, reason === r && styles.reasonTextSelected]}>{r}</Text>
+        </TouchableOpacity>
+      ))}
+    </View>
+  );
+
+  const renderOfferCard = (offer: RetentionOffer) => (
+    <Card key={offer.id} variant="elevated" style={styles.offerCard}>
+      <View style={styles.offerHeader}>
+        <Text style={styles.offerIcon}>{OFFER_TYPE_ICONS[offer.type] ?? '🎁'}</Text>
+        <View style={styles.offerHeaderText}>
+          <Text style={styles.offerTitle}>{offer.title}</Text>
+          <Text style={styles.offerBadge}>{offer.abVariant === 'A' ? 'Popular' : 'Best Value'}</Text>
+        </View>
+      </View>
+      <Text style={styles.offerDescription}>{offer.description}</Text>
+      <Text style={styles.offerExpiry}>
+        Expires: {new Date(offer.expiresAt).toLocaleDateString()}
+      </Text>
+      <Button
+        title="Claim This Offer"
+        variant="primary"
+        fullWidth
+        onPress={() => handleAcceptOffer(offer.id)}
+        style={styles.offerBtn}
+        accessibilityLabel={`Claim offer: ${offer.title}`}
+      />
+    </Card>
+  );
+
+  const renderOffersStep = () => (
+    <View>
+      <Text style={styles.stepLabel}>Step 2 of 3</Text>
+      <Text style={styles.heading}>Wait — we have something for you</Text>
+      <Text style={styles.subheading}>
+        Before you go, here are some options we put together for you.
+      </Text>
+      {offers.length === 0 ? (
+        <Card style={styles.noOffersCard}>
+          <Text style={styles.noOffersText}>No special offers available at this time.</Text>
+        </Card>
+      ) : (
+        offers.map(renderOfferCard)
+      )}
+      <Button
+        title="No thanks, continue to cancel"
+        variant="outline"
+        fullWidth
+        onPress={declineOffers}
+        style={styles.declineBtn}
+        accessibilityLabel="Decline all offers and continue to cancellation"
+      />
+    </View>
+  );
+
+  const renderConfirmStep = () => (
+    <View>
+      <Text style={styles.stepLabel}>Step 3 of 3</Text>
+      <Text style={styles.heading}>Confirm Cancellation</Text>
+      <Card variant="outlined" style={styles.confirmCard}>
+        <Text style={styles.confirmLabel}>Reason</Text>
+        <Text style={styles.confirmValue}>{reason}</Text>
+      </Card>
+      <Card variant="outlined" style={[styles.confirmCard, styles.warningCard]}>
+        <Text style={styles.warningText}>
+          ⚠️ Your subscription will remain active until the end of the current billing period. After
+          that, access will be revoked.
+        </Text>
+      </Card>
+      <Button
+        title="Confirm Cancellation"
+        variant="danger"
+        fullWidth
+        onPress={handleConfirmCancellation}
+        style={styles.confirmBtn}
+        accessibilityLabel="Confirm subscription cancellation"
+      />
+      <Button
+        title="Go Back"
+        variant="outline"
+        fullWidth
+        onPress={() => useCancellationStore.setState({ currentStep: 'OFFERS' })}
+        accessibilityLabel="Go back to retention offers"
+      />
+    </View>
+  );
+
+  const renderSuccessStep = () => {
+    const offerAccepted = acceptedOfferId !== null;
+    return (
+      <View style={styles.successContainer}>
+        <Text style={styles.successIcon}>{offerAccepted ? '🎉' : '✅'}</Text>
+        <Text style={styles.heading}>
+          {offerAccepted ? 'Offer Applied!' : 'Cancellation Confirmed'}
+        </Text>
+        <Text style={styles.subheading}>
+          {offerAccepted
+            ? 'Your retention offer has been applied to your account.'
+            : 'Your subscription has been cancelled. We hope to see you again.'}
+        </Text>
+        {cancellationRecord && (
+          <Card style={styles.recordCard}>
+            <Text style={styles.recordLabel}>Cool-off period ends</Text>
+            <Text style={styles.recordValue}>
+              {new Date(cancellationRecord.coolOffEndsAt).toLocaleDateString()}
+            </Text>
+            <Text style={styles.recordNote}>
+              You can reactivate your subscription before this date.
+            </Text>
+          </Card>
+        )}
+        <Button
+          title="Back to Dashboard"
+          variant="primary"
+          fullWidth
+          onPress={() => navigation.popToTop()}
+          style={styles.doneBtn}
+          accessibilityLabel="Return to dashboard"
+        />
+      </View>
+    );
   };
 
   const renderStep = () => {
     switch (currentStep) {
       case 'REASON':
-        return (
-          <View>
-            <Text style={styles.headerText}>Why are you leaving?</Text>
-            {['Too Expensive', 'Switching to Competitor', 'Technical Issues'].map((r) => (
-              <Button
-                key={r}
-                title={r}
-                variant="secondary"
-                onPress={() => setReason(r)}
-                style={styles.btn}
-              />
-            ))}
-          </View>
-        );
+        return renderReasonStep();
       case 'OFFERS':
-        return (
-          <View>
-            <Text style={styles.headerText}>Wait! We have a gift for you.</Text>
-            <Card style={styles.offerCard}>
-              <Text style={typography.body}>Get 20% off your next 3 months</Text>
-              <Button title="Claim Discount" onPress={() => acceptOffer('DISCOUNT_20')} />
-            </Card>
-            <Button
-              title="No thanks, continue to cancel"
-              variant="secondary"
-              onPress={() => setStep('CONFIRM')}
-            />
-          </View>
-        );
+        return renderOffersStep();
       case 'CONFIRM':
-        return (
-          <View>
-            <Text style={styles.headerText}>Are you sure?</Text>
-            <Text style={styles.infoText}>
-              Your access will continue until the end of the billing period.
-            </Text>
-            <Button
-              title="Confirm Cancellation"
-              variant="danger"
-              onPress={() => setStep('SUCCESS')}
-            />
-          </View>
-        );
+        return renderConfirmStep();
       case 'SUCCESS':
-        return (
-          <View>
-            <Text style={styles.headerText}>All set!</Text>
-            <Text style={styles.infoText}>
-              The request for subscription ID: {subscriptionId} has been processed successfully.
-            </Text>
-            <Button title="Back to Dashboard" onPress={handleFinalSuccess} />
-          </View>
-        );
+        return renderSuccessStep();
       default:
         return null;
     }
   };
 
-  return <ScrollView contentContainerStyle={styles.container}>{renderStep()}</ScrollView>;
+  return (
+    <ScrollView contentContainerStyle={styles.container} keyboardShouldPersistTaps="handled">
+      {isLoading && (
+        <View style={styles.loadingOverlay}>
+          <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+      )}
+      {error && (
+        <Card variant="outlined" style={styles.errorCard}>
+          <Text style={styles.errorText}>⚠️ {error}</Text>
+        </Card>
+      )}
+      {renderStep()}
+    </ScrollView>
+  );
 };
 
 const styles = StyleSheet.create({
@@ -92,24 +229,160 @@ const styles = StyleSheet.create({
     flexGrow: 1,
     backgroundColor: colors.background,
   },
-  headerText: {
-    ...typography.h2,
-    color: colors.text,
-    marginBottom: spacing.lg,
-  },
-  infoText: {
-    ...typography.body,
-    color: colors.textSecondary,
-    marginBottom: spacing.xl,
-  },
-  btn: {
+  loadingOverlay: {
+    alignItems: 'center',
     marginBottom: spacing.md,
   },
-  offerCard: {
+  stepLabel: {
+    ...typography.caption,
+    color: colors.textSecondary,
+    marginBottom: spacing.xs,
+  },
+  heading: {
+    ...typography.h2,
+    color: colors.text,
+    marginBottom: spacing.sm,
+  },
+  subheading: {
+    ...typography.body,
+    color: colors.textSecondary,
+    marginBottom: spacing.lg,
+  },
+  // Reason step
+  reasonOption: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: borderRadius.md,
     padding: spacing.md,
-    marginBottom: spacing.xl,
+    marginBottom: spacing.sm,
+    backgroundColor: colors.surface,
+  },
+  reasonOptionSelected: {
+    borderColor: colors.primary,
+    backgroundColor: colors.surfaceVariant,
+  },
+  reasonText: {
+    ...typography.body,
+    color: colors.textSecondary,
+  },
+  reasonTextSelected: {
+    color: colors.text,
+    fontWeight: '600',
+  },
+  // Offers step
+  offerCard: {
+    marginBottom: spacing.md,
     borderLeftWidth: 4,
     borderLeftColor: colors.primary,
+  },
+  offerHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: spacing.sm,
+  },
+  offerIcon: {
+    fontSize: 28,
+    marginRight: spacing.sm,
+  },
+  offerHeaderText: {
+    flex: 1,
+  },
+  offerTitle: {
+    ...typography.h3,
+    color: colors.text,
+  },
+  offerBadge: {
+    ...typography.small,
+    color: colors.accent,
+    marginTop: 2,
+  },
+  offerDescription: {
+    ...typography.body,
+    color: colors.textSecondary,
+    marginBottom: spacing.sm,
+  },
+  offerExpiry: {
+    ...typography.small,
+    color: colors.textSecondary,
+    marginBottom: spacing.md,
+  },
+  offerBtn: {
+    marginTop: spacing.xs,
+  },
+  noOffersCard: {
+    marginBottom: spacing.md,
+    alignItems: 'center',
+  },
+  noOffersText: {
+    ...typography.body,
+    color: colors.textSecondary,
+  },
+  declineBtn: {
+    marginTop: spacing.sm,
+  },
+  // Confirm step
+  confirmCard: {
+    marginBottom: spacing.md,
+  },
+  confirmLabel: {
+    ...typography.caption,
+    color: colors.textSecondary,
+    marginBottom: spacing.xs,
+  },
+  confirmValue: {
+    ...typography.body,
+    color: colors.text,
+  },
+  warningCard: {
+    borderColor: colors.warning,
+    backgroundColor: colors.warningBackground,
+  },
+  warningText: {
+    ...typography.body2,
+    color: colors.warning,
+  },
+  confirmBtn: {
+    marginBottom: spacing.sm,
+  },
+  // Success step
+  successContainer: {
+    alignItems: 'center',
+    paddingTop: spacing.xl,
+  },
+  successIcon: {
+    fontSize: 64,
+    marginBottom: spacing.lg,
+  },
+  recordCard: {
+    width: '100%',
+    marginTop: spacing.lg,
+    marginBottom: spacing.xl,
+  },
+  recordLabel: {
+    ...typography.caption,
+    color: colors.textSecondary,
+    marginBottom: spacing.xs,
+  },
+  recordValue: {
+    ...typography.h3,
+    color: colors.text,
+    marginBottom: spacing.xs,
+  },
+  recordNote: {
+    ...typography.body2,
+    color: colors.textSecondary,
+  },
+  doneBtn: {
+    width: '100%',
+  },
+  // Error
+  errorCard: {
+    marginBottom: spacing.md,
+    borderColor: colors.error,
+  },
+  errorText: {
+    ...typography.body2,
+    color: colors.error,
   },
 });
 

--- a/src/store/cancellationStore.ts
+++ b/src/store/cancellationStore.ts
@@ -1,30 +1,161 @@
 import { create } from 'zustand';
+import {
+  generateRetentionOffers,
+  acceptRetentionOffer,
+  recordCancellation,
+  categorizeCancellationReason,
+  RetentionOffer,
+  CancellationRecord,
+  UserSegmentContext,
+} from '../../backend/services/retentionService';
+import { useSubscriptionStore } from './subscriptionStore';
+import { useUserStore } from './userStore';
 
 export type CancellationStep = 'REASON' | 'OFFERS' | 'CONFIRM' | 'SUCCESS';
 
+export const CANCELLATION_REASONS = [
+  'Too Expensive',
+  'Switching to Competitor',
+  'Technical Issues',
+  'Missing Features',
+  'Not Using It',
+  'Other',
+] as const;
+
+export type CancellationReason = (typeof CANCELLATION_REASONS)[number];
+
 interface CancellationState {
   currentStep: CancellationStep;
+  subscriptionId: string | null;
   reason: string | null;
-  selectedOfferId: string | null;
+  offers: RetentionOffer[];
+  acceptedOfferId: string | null;
+  cancellationRecord: CancellationRecord | null;
+  isLoading: boolean;
+  error: string | null;
 
-  setStep: (step: CancellationStep) => void;
-  setReason: (reason: string) => void;
+  // Actions
+  initFlow: (subscriptionId: string) => void;
+  selectReason: (reason: string) => Promise<void>;
   acceptOffer: (offerId: string) => Promise<void>;
+  declineOffers: () => void;
+  confirmCancellation: () => Promise<void>;
   reset: () => void;
 }
 
-export const useCancellationStore = create<CancellationState>((set) => ({
-  currentStep: 'REASON',
+const initialState = {
+  currentStep: 'REASON' as CancellationStep,
+  subscriptionId: null,
   reason: null,
-  selectedOfferId: null,
+  offers: [],
+  acceptedOfferId: null,
+  cancellationRecord: null,
+  isLoading: false,
+  error: null,
+};
 
-  setStep: (step) => set({ currentStep: step }),
-  setReason: (reason) => set({ reason, currentStep: 'OFFERS' }),
+function buildSegmentContext(subscriptionId: string): UserSegmentContext | null {
+  const { subscriptions } = useSubscriptionStore.getState();
+  const { user, subscriptionTier } = useUserStore.getState();
 
-  acceptOffer: async (offerId) => {
-    // Logic to call apply_retention_offer on Soroban
-    set({ selectedOfferId: offerId, currentStep: 'SUCCESS' });
+  const sub = subscriptions.find((s) => s.id === subscriptionId);
+  if (!sub || !user) return null;
+
+  const totalMonthlySpend = subscriptions
+    .filter((s) => s.isActive)
+    .reduce((acc, s) => acc + (s.billingCycle === 'monthly' ? s.price : s.price / 12), 0);
+
+  const createdAt = sub.createdAt ? new Date(sub.createdAt) : new Date();
+  const monthsActive = Math.max(
+    1,
+    Math.floor((Date.now() - createdAt.getTime()) / (1000 * 60 * 60 * 24 * 30))
+  );
+
+  return {
+    userId: user.id,
+    subscriptionId: sub.id,
+    subscriptionName: sub.name,
+    monthlyPrice: sub.billingCycle === 'monthly' ? sub.price : sub.price / 12,
+    monthsActive,
+    totalMonthlySpend,
+    subscriptionTier,
+  };
+}
+
+export const useCancellationStore = create<CancellationState>((set, get) => ({
+  ...initialState,
+
+  initFlow: (subscriptionId) => {
+    set({ ...initialState, subscriptionId });
   },
 
-  reset: () => set({ currentStep: 'REASON', reason: null, selectedOfferId: null }),
+  selectReason: async (reason) => {
+    set({ isLoading: true, error: null, reason });
+    try {
+      const { subscriptionId } = get();
+      if (!subscriptionId) throw new Error('No subscription selected');
+
+      const context = buildSegmentContext(subscriptionId);
+      if (!context) throw new Error('Could not load subscription context');
+
+      const reasonCategory = categorizeCancellationReason(reason);
+      const offers = generateRetentionOffers(context, reasonCategory);
+
+      set({ offers, currentStep: 'OFFERS', isLoading: false });
+    } catch (e) {
+      set({ error: e instanceof Error ? e.message : 'Failed to load offers', isLoading: false });
+    }
+  },
+
+  acceptOffer: async (offerId) => {
+    set({ isLoading: true, error: null });
+    try {
+      const { user } = useUserStore.getState();
+      if (!user) throw new Error('User not found');
+
+      const result = acceptRetentionOffer(user.id, offerId);
+      if (!result.accepted) throw new Error('Offer is no longer valid or has expired');
+
+      set({ acceptedOfferId: offerId, currentStep: 'SUCCESS', isLoading: false });
+    } catch (e) {
+      set({ error: e instanceof Error ? e.message : 'Failed to accept offer', isLoading: false });
+    }
+  },
+
+  declineOffers: () => {
+    set({ currentStep: 'CONFIRM' });
+  },
+
+  confirmCancellation: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const { subscriptionId, reason, offers, acceptedOfferId } = get();
+      const { user } = useUserStore.getState();
+
+      if (!subscriptionId || !reason || !user) throw new Error('Missing cancellation data');
+
+      const record = recordCancellation(
+        user.id,
+        subscriptionId,
+        reason,
+        offers.map((o) => o.id),
+        acceptedOfferId
+      );
+
+      // Mark subscription as inactive in local store
+      const { updateSubscription } = useSubscriptionStore.getState();
+      if (updateSubscription) {
+        updateSubscription(subscriptionId, { isActive: false });
+      }
+
+      set({ cancellationRecord: record, currentStep: 'SUCCESS', isLoading: false });
+    } catch (e) {
+      set({
+        error: e instanceof Error ? e.message : 'Failed to process cancellation',
+        isLoading: false,
+      });
+    }
+  },
+
+  reset: () => set(initialState),
 }));


### PR DESCRIPTION
- Add retentionService with segment-based offer engine, A/B testing, offer expiry (24h TTL), and abuse prevention (max 2 accepts/year)
- Add cancellationStore with reason collection, offer loading, accept/decline, confirm cancellation, and win-back trigger
- Rewrite CancellationFlowScreen with 4-step flow: reason selection, retention offers, confirmation with cool-off period, success state
- Cancellation records cool-off period (3 days) before win-back fires


Closes #388