### PR TITLE
Feat: analytics-webhoo-event-sourcing-groups/family: Subtrackr

### DIFF
--- a/backend/ml/churnModel.py
+++ b/backend/ml/churnModel.py
@@ -85,6 +85,35 @@ class ChurnPredictionModel:
         else:
             return "Offer a 1-month free subscription to retain user."
 
+
+class RevenueForecastModel:
+    def forecast(self, observations: List[Dict], horizon: int = 3) -> List[Dict]:
+        values = [float(item.get("revenue", 0)) for item in observations]
+        if not values:
+            return []
+
+        latest = values[-1]
+        deltas = [values[index] - values[index - 1] for index in range(1, len(values))]
+        average_delta = sum(deltas) / len(deltas) if deltas else 0
+        variance = (
+            sum((delta - average_delta) ** 2 for delta in deltas) / len(deltas)
+            if deltas
+            else max(latest * 0.05, 1)
+        )
+        deviation = math.sqrt(variance)
+
+        forecast = []
+        for step in range(1, horizon + 1):
+            expected = max(0, latest + average_delta * step)
+            confidence = deviation * math.sqrt(step) * 1.96
+            forecast.append({
+                "period": f"forecast_{step}",
+                "expected_revenue": round(expected, 2),
+                "lower_bound": round(max(0, expected - confidence), 2),
+                "upper_bound": round(expected + confidence, 2),
+            })
+        return forecast
+
 if __name__ == "__main__":
     model = ChurnPredictionModel()
     test_data = {

--- a/backend/services/index.ts
+++ b/backend/services/index.ts
@@ -19,3 +19,13 @@ export {
   isWebhookEventAllowed,
 } from './webhook';
 export type { RegisterWebhookInput, WebhookDeliveryResult, WebhookEventInput } from './webhook';
+export {
+  SubscriptionEventStore,
+  subscriptionEventStore,
+} from './subscriptionEventStore';
+export type {
+  SubscriptionEvent,
+  SubscriptionEventPage,
+  SubscriptionEventQuery,
+  SubscriptionEventType,
+} from './subscriptionEventStore';

--- a/backend/services/predictionService.ts
+++ b/backend/services/predictionService.ts
@@ -21,6 +21,18 @@ export interface UserChurnData {
   priceSensitivityIndex: number;
 }
 
+export interface RevenueObservation {
+  period: string;
+  revenue: number;
+}
+
+export interface ForecastPoint {
+  period: string;
+  expectedRevenue: number;
+  lowerBound: number;
+  upperBound: number;
+}
+
 export class PredictionService {
   // Path for future Python bridge integration
   private static readonly _PYTHON_PATH = path.join(__dirname, '../ml/churnModel.py');
@@ -80,5 +92,35 @@ export class PredictionService {
     } catch (error) {
       throw new Error('Failed to fetch risk factors');
     }
+  }
+
+  static async forecastRevenue(
+    observations: RevenueObservation[],
+    horizon = 3
+  ): Promise<ForecastPoint[]> {
+    if (observations.length === 0) return [];
+
+    const values = observations.map((entry) => entry.revenue);
+    const latest = values[values.length - 1];
+    const deltas = values.slice(1).map((value, index) => value - values[index]);
+    const averageDelta = deltas.length
+      ? deltas.reduce((sum, delta) => sum + delta, 0) / deltas.length
+      : 0;
+    const variance = deltas.length
+      ? deltas.reduce((sum, delta) => sum + Math.pow(delta - averageDelta, 2), 0) / deltas.length
+      : Math.max(latest * 0.05, 1);
+    const deviation = Math.sqrt(variance);
+
+    return Array.from({ length: horizon }, (_, index) => {
+      const step = index + 1;
+      const expectedRevenue = Math.max(0, latest + averageDelta * step);
+      const confidence = deviation * Math.sqrt(step) * 1.96;
+      return {
+        period: `forecast_${step}`,
+        expectedRevenue: Number(expectedRevenue.toFixed(2)),
+        lowerBound: Number(Math.max(0, expectedRevenue - confidence).toFixed(2)),
+        upperBound: Number((expectedRevenue + confidence).toFixed(2)),
+      };
+    });
   }
 }

--- a/backend/services/subscriptionEventStore.ts
+++ b/backend/services/subscriptionEventStore.ts
@@ -1,0 +1,108 @@
+export type SubscriptionEventType =
+  | 'subscription.created'
+  | 'subscription.updated'
+  | 'subscription.renewed'
+  | 'subscription.cancelled'
+  | 'subscription.payment_failed'
+  | 'subscription.upgraded'
+  | 'subscription.paused'
+  | 'subscription.resumed';
+
+export interface SubscriptionEvent<TPayload extends Record<string, unknown> = Record<string, unknown>> {
+  id: string;
+  subscriptionId: string;
+  sequence: number;
+  type: SubscriptionEventType;
+  payload: TPayload;
+  occurredAt: number;
+  schemaVersion: number;
+  archivedAt?: number;
+}
+
+export interface SubscriptionEventQuery {
+  subscriptionId?: string;
+  type?: SubscriptionEventType;
+  from?: number;
+  to?: number;
+  limit?: number;
+  cursor?: number;
+  includeArchived?: boolean;
+}
+
+export interface SubscriptionEventPage {
+  events: SubscriptionEvent[];
+  nextCursor?: number;
+}
+
+export class SubscriptionEventStore {
+  private readonly events: SubscriptionEvent[] = [];
+  private readonly sequenceBySubscription = new Map<string, number>();
+
+  append<TPayload extends Record<string, unknown> = Record<string, unknown>>(
+    event: Omit<SubscriptionEvent<TPayload>, 'id' | 'sequence' | 'occurredAt' | 'schemaVersion'> &
+      Partial<Pick<SubscriptionEvent, 'occurredAt' | 'schemaVersion'>>
+  ): SubscriptionEvent<TPayload> {
+    const nextSequence = (this.sequenceBySubscription.get(event.subscriptionId) ?? 0) + 1;
+    this.sequenceBySubscription.set(event.subscriptionId, nextSequence);
+
+    const record: SubscriptionEvent<TPayload> = {
+      ...event,
+      id: `sev_${Date.now().toString(36)}_${nextSequence}`,
+      sequence: nextSequence,
+      occurredAt: event.occurredAt ?? Date.now(),
+      schemaVersion: event.schemaVersion ?? 1,
+    };
+    this.events.push(record);
+    return record;
+  }
+
+  query(query: SubscriptionEventQuery = {}): SubscriptionEventPage {
+    const cursor = query.cursor ?? 0;
+    const limit = Math.max(1, query.limit ?? 50);
+    const filtered = this.events.filter((event) => {
+      if (!query.includeArchived && event.archivedAt) return false;
+      if (query.subscriptionId && event.subscriptionId !== query.subscriptionId) return false;
+      if (query.type && event.type !== query.type) return false;
+      if (query.from && event.occurredAt < query.from) return false;
+      if (query.to && event.occurredAt > query.to) return false;
+      return true;
+    });
+    const events = filtered.slice(cursor, cursor + limit);
+    const nextCursor = cursor + limit < filtered.length ? cursor + limit : undefined;
+    return { events, nextCursor };
+  }
+
+  reconstruct(subscriptionId: string): Record<string, unknown> {
+    return this.query({ subscriptionId, includeArchived: true, limit: Number.MAX_SAFE_INTEGER })
+      .events.sort((a, b) => a.sequence - b.sequence)
+      .reduce<Record<string, unknown>>(
+        (state, event) => ({
+          ...state,
+          ...(event.payload as Record<string, unknown>),
+          id: subscriptionId,
+          lastEventType: event.type,
+          updatedAt: event.occurredAt,
+        }),
+        { id: subscriptionId }
+      );
+  }
+
+  replay(subscriptionId: string, handler: (event: SubscriptionEvent) => void): void {
+    this.query({ subscriptionId, includeArchived: true, limit: Number.MAX_SAFE_INTEGER })
+      .events.sort((a, b) => a.sequence - b.sequence)
+      .forEach(handler);
+  }
+
+  archiveBefore(timestamp: number): number {
+    let archived = 0;
+    for (const event of this.events) {
+      if (!event.archivedAt && event.occurredAt < timestamp) {
+        event.archivedAt = Date.now();
+        archived += 1;
+      }
+    }
+    return archived;
+  }
+}
+
+export const subscriptionEventStore = new SubscriptionEventStore();

--- a/backend/services/webhook.ts
+++ b/backend/services/webhook.ts
@@ -20,6 +20,7 @@ export interface RegisterWebhookInput {
   events: WebhookEventType[];
   secretKey: string;
   retryPolicy?: Partial<WebhookRetryPolicy>;
+  rateLimitPerMinute?: number;
   isPaused?: boolean;
 }
 
@@ -94,6 +95,7 @@ export class WebhookDeliveryService {
   private readonly webhooks = new Map<string, WebhookConfig>();
   private readonly deliveries = new Map<string, WebhookDelivery>();
   private readonly deliveredKeys = new Set<string>();
+  private readonly rateLimitWindows = new Map<string, number[]>();
 
   constructor(options: { fetchImpl?: FetchLike; sleepImpl?: (ms: number) => Promise<void> } = {}) {
     this.fetchImpl = options.fetchImpl ?? fetch;
@@ -110,6 +112,7 @@ export class WebhookDeliveryService {
       events: [...input.events],
       secretKey: input.secretKey,
       retryPolicy: clampRetryPolicy(input.retryPolicy),
+      rateLimitPerMinute: input.rateLimitPerMinute,
       isPaused: input.isPaused ?? false,
       createdAt,
       updatedAt: createdAt,
@@ -136,6 +139,7 @@ export class WebhookDeliveryService {
       events: input.events ? [...input.events] : existing.events,
       secretKey: input.secretKey ?? existing.secretKey,
       retryPolicy: clampRetryPolicy(input.retryPolicy ?? existing.retryPolicy),
+      rateLimitPerMinute: input.rateLimitPerMinute ?? existing.rateLimitPerMinute,
       isPaused: input.isPaused ?? existing.isPaused,
       updatedAt: now(),
     };
@@ -193,6 +197,9 @@ export class WebhookDeliveryService {
     const avgAttempts = totalDeliveries
       ? deliveries.reduce((sum, d) => sum + d.attempts, 0) / totalDeliveries
       : 0;
+    const latencySamples = deliveries
+      .map((delivery) => delivery.latencyMs)
+      .filter((latency): latency is number => typeof latency === 'number');
 
     return {
       webhookId,
@@ -203,6 +210,9 @@ export class WebhookDeliveryService {
       pendingDeliveries,
       successRate: totalDeliveries ? successfulDeliveries / totalDeliveries : 0,
       avgAttempts,
+      avgLatencyMs: latencySamples.length
+        ? latencySamples.reduce((sum, latency) => sum + latency, 0) / latencySamples.length
+        : 0,
       lastSuccessAt: deliveries
         .filter((delivery) => delivery.status === 'delivered' && delivery.deliveredAt)
         .map((delivery) => delivery.deliveredAt as number)
@@ -265,6 +275,28 @@ export class WebhookDeliveryService {
         updatedAt: now(),
         signature,
         idempotencyKey,
+      };
+      this.deliveries.set(delivery.id, delivery);
+      return { delivery };
+    }
+
+    if (this.isRateLimited(webhook)) {
+      const delivery: WebhookDelivery = {
+        id: createId('del'),
+        webhookId: webhook.id,
+        eventId: payload.id,
+        eventType: payload.eventType,
+        url: webhook.url,
+        payload,
+        status: 'retrying',
+        attempts: 0,
+        maxAttempts: webhook.retryPolicy.maxRetries,
+        createdAt: now(),
+        updatedAt: now(),
+        signature,
+        idempotencyKey,
+        errorMessage: 'Webhook endpoint rate limited',
+        nextRetryAt: now() + 60_000,
       };
       this.deliveries.set(delivery.id, delivery);
       return { delivery };
@@ -375,6 +407,7 @@ export class WebhookDeliveryService {
             status: 'delivered',
             responseCode: response.status,
             deliveredAt: now(),
+            latencyMs: now() - attemptAt,
           },
           response
         );
@@ -441,6 +474,21 @@ export class WebhookDeliveryService {
     const factor = policy.backoffFactor ?? DEFAULT_RETRY_POLICY.backoffFactor ?? 2;
     const rawDelay = Math.floor(policy.initialDelayMs * Math.pow(factor, Math.max(0, attempt - 1)));
     return Math.min(rawDelay, policy.maxDelayMs);
+  }
+
+  private isRateLimited(webhook: WebhookConfig): boolean {
+    if (!webhook.rateLimitPerMinute || webhook.rateLimitPerMinute <= 0) return false;
+    const windowStart = now() - 60_000;
+    const current = (this.rateLimitWindows.get(webhook.id) ?? []).filter(
+      (timestamp) => timestamp >= windowStart
+    );
+    if (current.length >= webhook.rateLimitPerMinute) {
+      this.rateLimitWindows.set(webhook.id, current);
+      return true;
+    }
+    current.push(now());
+    this.rateLimitWindows.set(webhook.id, current);
+    return false;
   }
 }
 

--- a/contracts/subscription/src/events.rs
+++ b/contracts/subscription/src/events.rs
@@ -1,8 +1,67 @@
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{contracttype, Address, Env, String, Vec};
 use subtrackr_types::{
     Plan, Subscription, SubscriptionStatus, WebhookEventPayload, WebhookEventType,
     WebhookPlanSnapshot, WebhookSubscriptionSnapshot,
 };
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum SubscriptionEventType {
+    Created,
+    Updated,
+    Renewed,
+    Cancelled,
+    PaymentFailed,
+    Upgraded,
+    Paused,
+    Resumed,
+    RefundRequested,
+    RefundApproved,
+    RefundRejected,
+    TransferRequested,
+    TransferAccepted,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct SubscriptionAuditEvent {
+    pub id: u64,
+    pub subscription_id: u64,
+    pub sequence: u64,
+    pub event_type: SubscriptionEventType,
+    pub actor: Address,
+    pub occurred_at: u64,
+    pub schema_version: u32,
+    pub payload_hash: String,
+}
+
+pub(crate) fn build_audit_event(
+    env: &Env,
+    subscription_id: u64,
+    sequence: u64,
+    event_type: SubscriptionEventType,
+    actor: &Address,
+    payload_hash: String,
+) -> SubscriptionAuditEvent {
+    SubscriptionAuditEvent {
+        id: env.ledger().sequence() as u64,
+        subscription_id,
+        sequence,
+        event_type,
+        actor: actor.clone(),
+        occurred_at: env.ledger().timestamp(),
+        schema_version: 1,
+        payload_hash,
+    }
+}
+
+pub(crate) fn replay_state(events: Vec<SubscriptionAuditEvent>) -> Option<SubscriptionEventType> {
+    let mut latest: Option<SubscriptionEventType> = None;
+    for event in events.iter() {
+        latest = Some(event.event_type);
+    }
+    latest
+}
 
 pub(crate) fn subscription_snapshot(sub: &Subscription) -> WebhookSubscriptionSnapshot {
     WebhookSubscriptionSnapshot {

--- a/contracts/subscription/src/lib.rs
+++ b/contracts/subscription/src/lib.rs
@@ -13,6 +13,46 @@ const MAX_PAUSE_DURATION: u64 = 2_592_000; // 30 days
 
 const STORAGE_VERSION: u32 = 2;
 
+#[soroban_sdk::contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum GroupMemberRole {
+    Owner,
+    Admin,
+    Member,
+}
+
+#[soroban_sdk::contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct GroupMember {
+    pub address: Address,
+    pub role: GroupMemberRole,
+    pub joined_at: u64,
+    pub usage_units: u64,
+    pub outstanding_balance: i128,
+}
+
+#[soroban_sdk::contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct FamilyPlanRules {
+    pub seat_limit: u32,
+    pub family_plan_price: i128,
+    pub owner_pays_for_members: bool,
+    pub allow_member_overages: bool,
+}
+
+#[soroban_sdk::contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct SubscriptionGroup {
+    pub id: u64,
+    pub owner: Address,
+    pub name: String,
+    pub members: Vec<GroupMember>,
+    pub rules: FamilyPlanRules,
+    pub billing_address: String,
+    pub created_at: u64,
+    pub updated_at: u64,
+}
+
 fn storage_instance_get<V: TryFromVal<Env, Val>>(
     env: &Env,
     storage: &Address,

--- a/src/screens/AnalyticsScreen.tsx
+++ b/src/screens/AnalyticsScreen.tsx
@@ -15,6 +15,7 @@ import { SubscriptionCategory, BillingCycle } from '../types/subscription';
 import { Card } from '../components/common/Card';
 import { useSettingsStore } from '../store/settingsStore';
 import { currencyService } from '../services/currencyService';
+import { calculateSubscriptionAnalytics } from '../services/analyticsService';
 import { formatCurrency } from '../utils/formatting';
 
 
@@ -47,6 +48,11 @@ const AnalyticsScreen: React.FC = () => {
       }))
       .filter((d) => d.count > 0);
   }, [stats]);
+
+  const subscriptionAnalytics = useMemo(
+    () => calculateSubscriptionAnalytics(subscriptions || []),
+    [subscriptions]
+  );
 
   const monthlyData = useMemo(() => {
     if (!subscriptions?.length)
@@ -207,6 +213,41 @@ const AnalyticsScreen: React.FC = () => {
 
           </Card>
         </View>
+        <View style={styles.summaryContainer}>
+          <Card style={styles.summaryCard}>
+            <Text style={styles.summaryLabel}>MRR</Text>
+            <Text style={styles.summaryValue}>
+              {formatCurrency(subscriptionAnalytics.mrr, preferredCurrency)}
+            </Text>
+          </Card>
+          <Card style={styles.summaryCard}>
+            <Text style={styles.summaryLabel}>ARR</Text>
+            <Text style={styles.summaryValue}>
+              {formatCurrency(subscriptionAnalytics.arr, preferredCurrency)}
+            </Text>
+          </Card>
+        </View>
+        <Card style={styles.chartCard}>
+          <Text style={styles.chartTitle}>Revenue Health</Text>
+          <View style={styles.projectionItem}>
+            <Text style={styles.projectionLabel}>Gross churn</Text>
+            <Text style={styles.projectionValue}>
+              {(subscriptionAnalytics.churn.grossChurnRate * 100).toFixed(1)}%
+            </Text>
+          </View>
+          <View style={styles.projectionItem}>
+            <Text style={styles.projectionLabel}>Net churn</Text>
+            <Text style={styles.projectionValue}>
+              {(subscriptionAnalytics.churn.netChurnRate * 100).toFixed(1)}%
+            </Text>
+          </View>
+          <View style={[styles.projectionItem, styles.projectionItemLast]}>
+            <Text style={styles.projectionLabel}>LTV</Text>
+            <Text style={styles.projectionValue}>
+              {formatCurrency(subscriptionAnalytics.ltv, preferredCurrency)}
+            </Text>
+          </View>
+        </Card>
         <Card style={styles.chartCard}>
           <Text style={styles.chartTitle}>
             {dateRange === 'week' ? 'Weekly' : dateRange === 'month' ? 'Monthly' : 'Yearly'}{' '}
@@ -266,6 +307,33 @@ const AnalyticsScreen: React.FC = () => {
               );
             })}
           </Svg>
+        </Card>
+        <Card style={styles.chartCard}>
+          <Text style={styles.chartTitle}>Cohorts</Text>
+          {subscriptionAnalytics.cohorts.slice(-4).map((cohort) => (
+            <View key={cohort.cohort} style={styles.projectionItem}>
+              <Text style={styles.projectionLabel}>{cohort.cohort}</Text>
+              <Text style={styles.projectionValue}>
+                {(cohort.retentionRate * 100).toFixed(0)}% retained
+              </Text>
+            </View>
+          ))}
+        </Card>
+        <Card style={styles.chartCard}>
+          <Text style={styles.chartTitle}>Forecast</Text>
+          {subscriptionAnalytics.forecast.map((point, index) => (
+            <View
+              key={point.label}
+              style={[
+                styles.projectionItem,
+                index === subscriptionAnalytics.forecast.length - 1 && styles.projectionItemLast,
+              ]}>
+              <Text style={styles.projectionLabel}>{point.label}</Text>
+              <Text style={styles.projectionValue}>
+                {formatCurrency(point.expectedRevenue, preferredCurrency)}
+              </Text>
+            </View>
+          ))}
         </Card>
         <Card style={styles.chartCard}>
           <Text style={styles.chartTitle}>Category Breakdown</Text>

--- a/src/screens/SubscriptionDetailScreen.tsx
+++ b/src/screens/SubscriptionDetailScreen.tsx
@@ -18,6 +18,7 @@ import { formatCurrency } from '../utils/formatting';
 import { colors, spacing, typography } from '../utils/constants';
 import { getCategoryIcon } from '../utils/subscriptionHelpers';
 import { RootStackParamList } from '../navigation/types';
+import { useGroupStore } from '../store/groupStore';
 
 // Components
 import { Button } from '../components/common/Button';
@@ -34,10 +35,15 @@ const SubscriptionDetailScreen: React.FC = () => {
 
   const { subscriptions, toggleSubscriptionStatus, updateSubscription, recordBillingOutcome } =
     useSubscriptionStore();
+  const { groups } = useGroupStore();
   const { preferredCurrency, exchangeRates } = useSettingsStore();
   const rates = exchangeRates?.rates || {};
 
   const subscription = useMemo(() => subscriptions?.find((s) => s.id === id), [id, subscriptions]);
+  const subscriptionGroup = useMemo(
+    () => groups.find((group) => group.groupId === subscription?.groupId),
+    [groups, subscription?.groupId]
+  );
 
   const [loading, setLoading] = useState(!subscription);
 
@@ -178,6 +184,30 @@ const SubscriptionDetailScreen: React.FC = () => {
               </Text>
             </View>
           </Card>
+
+          {subscriptionGroup ? (
+            <Card style={styles.standardCard}>
+              <Text style={styles.sectionTitle}>Group plan</Text>
+              <View style={styles.dataRow}>
+                <Text style={styles.dataLabel}>Group</Text>
+                <Text style={styles.dataValue}>{subscriptionGroup.name}</Text>
+              </View>
+              <View style={styles.dataRow}>
+                <Text style={styles.dataLabel}>Seats</Text>
+                <Text style={styles.dataValue}>
+                  {subscriptionGroup.members.length}/{subscriptionGroup.planSharingRules.seatLimit}
+                </Text>
+              </View>
+              <View style={styles.dataRow}>
+                <Text style={styles.dataLabel}>Billing</Text>
+                <Text style={styles.dataValue}>
+                  {subscriptionGroup.planSharingRules.ownerPaysForMembers
+                    ? 'Consolidated'
+                    : 'Member split'}
+                </Text>
+              </View>
+            </Card>
+          ) : null}
 
           {/* Notifications */}
           <Card style={styles.statusCard}>

--- a/src/screens/WebhookSettingsScreen.tsx
+++ b/src/screens/WebhookSettingsScreen.tsx
@@ -36,13 +36,14 @@ const WebhookSettingsScreen: React.FC = () => {
     pauseWebhook,
     resumeWebhook,
     retryDelivery,
+    sendTestEvent,
     refreshAnalytics,
   } = useWebhookStore();
 
   const [form, setForm] = useState(emptyWebhookForm);
   const [selectedEvents, setSelectedEvents] = useState<WebhookEventType[]>([
     'subscription.created',
-    'subscription.updated',
+    'subscription.renewed',
     'subscription.cancelled',
   ]);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -53,7 +54,7 @@ const WebhookSettingsScreen: React.FC = () => {
 
   const resetForm = () => {
     setForm(emptyWebhookForm);
-    setSelectedEvents(['subscription.created', 'subscription.updated', 'subscription.cancelled']);
+    setSelectedEvents(['subscription.created', 'subscription.renewed', 'subscription.cancelled']);
     setEditingId(null);
   };
 
@@ -207,6 +208,9 @@ const WebhookSettingsScreen: React.FC = () => {
                 </Text>
                 <Text style={styles.analyticsLabel}>success rate</Text>
               </View>
+              <Text style={styles.webhookMeta}>
+                Avg latency: {Math.round(webhookAnalytics?.avgLatencyMs ?? 0)}ms
+              </Text>
 
               <View style={styles.actionRow}>
                 <TouchableOpacity
@@ -220,6 +224,11 @@ const WebhookSettingsScreen: React.FC = () => {
                 </TouchableOpacity>
                 <TouchableOpacity style={styles.actionButton} onPress={() => startEdit(webhook)}>
                   <Text style={styles.actionButtonText}>Edit</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={styles.actionButton}
+                  onPress={() => sendTestEvent(webhook.id, webhook.events[0])}>
+                  <Text style={styles.actionButtonText}>Send test</Text>
                 </TouchableOpacity>
                 <TouchableOpacity
                   style={styles.actionButtonDanger}

--- a/src/services/analyticsService.ts
+++ b/src/services/analyticsService.ts
@@ -1,0 +1,131 @@
+import { BillingCycle, Subscription } from '../types/subscription';
+
+export interface RevenuePoint {
+  label: string;
+  mrr: number;
+  arr: number;
+}
+
+export interface ChurnMetrics {
+  grossChurnRate: number;
+  netChurnRate: number;
+  churnedSubscriptions: number;
+  activeSubscriptions: number;
+}
+
+export interface CohortMetric {
+  cohort: string;
+  subscriptionsStarted: number;
+  activeSubscriptions: number;
+  retentionRate: number;
+  revenue: number;
+}
+
+export interface RevenueForecastPoint {
+  label: string;
+  expectedRevenue: number;
+  lowerBound: number;
+  upperBound: number;
+}
+
+export interface SubscriptionAnalyticsReport {
+  mrr: number;
+  arr: number;
+  ltv: number;
+  churn: ChurnMetrics;
+  revenueTrend: RevenuePoint[];
+  cohorts: CohortMetric[];
+  forecast: RevenueForecastPoint[];
+}
+
+const MONTHS_PER_YEAR = 12;
+const WEEKS_PER_MONTH = 4.345;
+
+export const toMonthlyRevenue = (subscription: Pick<Subscription, 'price' | 'billingCycle'>): number => {
+  if (subscription.billingCycle === BillingCycle.YEARLY) return subscription.price / MONTHS_PER_YEAR;
+  if (subscription.billingCycle === BillingCycle.WEEKLY) return subscription.price * WEEKS_PER_MONTH;
+  return subscription.price;
+};
+
+const monthKey = (date: Date): string =>
+  `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+
+export const calculateSubscriptionAnalytics = (
+  subscriptions: Subscription[],
+  asOf = new Date()
+): SubscriptionAnalyticsReport => {
+  const active = subscriptions.filter((subscription) => subscription.isActive);
+  const inactive = subscriptions.filter((subscription) => !subscription.isActive);
+  const mrr = active.reduce((sum, subscription) => sum + toMonthlyRevenue(subscription), 0);
+  const arr = mrr * MONTHS_PER_YEAR;
+  const churnDenominator = Math.max(subscriptions.length, 1);
+  const grossChurnRate = inactive.length / churnDenominator;
+  const expansionRevenue = active.reduce((sum, subscription) => {
+    const createdAt = new Date(subscription.createdAt);
+    return createdAt < asOf ? sum + Math.max(0, toMonthlyRevenue(subscription) * 0.03) : sum;
+  }, 0);
+  const churnedRevenue = inactive.reduce(
+    (sum, subscription) => sum + toMonthlyRevenue(subscription),
+    0
+  );
+  const netChurnRate = mrr + churnedRevenue > 0 ? Math.max(0, (churnedRevenue - expansionRevenue) / (mrr + churnedRevenue)) : 0;
+  const averageMonthlyRevenue = active.length ? mrr / active.length : 0;
+  const ltv = grossChurnRate > 0 ? averageMonthlyRevenue / grossChurnRate : averageMonthlyRevenue * MONTHS_PER_YEAR;
+
+  const cohorts = Array.from(
+    subscriptions.reduce((map, subscription) => {
+      const key = monthKey(new Date(subscription.createdAt));
+      const entries = map.get(key) ?? [];
+      entries.push(subscription);
+      map.set(key, entries);
+      return map;
+    }, new Map<string, Subscription[]>())
+  )
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([cohort, entries]) => {
+      const activeSubscriptions = entries.filter((subscription) => subscription.isActive).length;
+      return {
+        cohort,
+        subscriptionsStarted: entries.length,
+        activeSubscriptions,
+        retentionRate: entries.length ? activeSubscriptions / entries.length : 0,
+        revenue: entries.reduce((sum, subscription) => sum + toMonthlyRevenue(subscription), 0),
+      };
+    });
+
+  const revenueTrend = cohorts.slice(-6).map((cohort) => ({
+    label: cohort.cohort,
+    mrr: cohort.revenue,
+    arr: cohort.revenue * MONTHS_PER_YEAR,
+  }));
+
+  const retention = cohorts.length
+    ? cohorts.reduce((sum, cohort) => sum + cohort.retentionRate, 0) / cohorts.length
+    : 1;
+  const confidenceBand = Math.max(0.1, 1 - Math.min(subscriptions.length / 50, 0.8));
+  const forecast = Array.from({ length: 3 }, (_, index) => {
+    const monthAhead = index + 1;
+    const expectedRevenue = mrr * Math.pow(retention || 0.95, monthAhead);
+    return {
+      label: `M+${monthAhead}`,
+      expectedRevenue,
+      lowerBound: expectedRevenue * (1 - confidenceBand),
+      upperBound: expectedRevenue * (1 + confidenceBand),
+    };
+  });
+
+  return {
+    mrr,
+    arr,
+    ltv,
+    churn: {
+      grossChurnRate,
+      netChurnRate,
+      churnedSubscriptions: inactive.length,
+      activeSubscriptions: active.length,
+    },
+    revenueTrend,
+    cohorts,
+    forecast,
+  };
+};

--- a/src/services/groupService.ts
+++ b/src/services/groupService.ts
@@ -4,6 +4,7 @@ import {
   GroupConfig,
   GroupInvite,
   GroupMember,
+  GroupMemberRole,
   GroupPlanSharingRules,
   SubscriptionGroup,
 } from '../types/group';
@@ -22,6 +23,7 @@ export const createSubscriptionGroup = (owner: string, config: GroupConfig): Sub
   const ownerMember: GroupMember = {
     address: owner,
     role: 'owner',
+    permissions: ['invite', 'remove', 'billing', 'analytics'],
     joinedAt: now,
     outstandingBalance: 0,
     usageUnits: 0,
@@ -84,6 +86,7 @@ export const joinGroupWithInvite = (
     address: invite.inviteeAddress,
     displayName,
     role: 'member',
+    permissions: ['view'],
     joinedAt: new Date(),
     outstandingBalance: 0,
     usageUnits: 0,
@@ -116,8 +119,9 @@ export const removeGroupMember = (group: SubscriptionGroup, memberAddress: strin
 export const chargeGroup = (group: SubscriptionGroup, amount: number): GroupChargeResult => {
   if (amount <= 0) throw new Error('Charge amount must be greater than zero');
 
+  const billableAmount = group.planSharingRules.familyPlanPrice ?? amount;
   const payer = group.planSharingRules.ownerPaysForMembers ? group.owner : 'members';
-  const memberShare = amount / Math.max(group.members.length, 1);
+  const memberShare = billableAmount / Math.max(group.members.length, 1);
   const breakdown = group.members.map((member) => ({
     memberAddress: member.address,
     amount: group.planSharingRules.ownerPaysForMembers ? 0 : Number(memberShare.toFixed(2)),
@@ -130,7 +134,7 @@ export const chargeGroup = (group: SubscriptionGroup, amount: number): GroupChar
   return {
     groupId: group.groupId,
     payer,
-    amount,
+    amount: billableAmount,
     breakdown,
     chargedAt: new Date(),
   };
@@ -143,4 +147,32 @@ export const getGroupAnalytics = (group: SubscriptionGroup): GroupAnalytics => (
   totalUsage: group.members.reduce((sum, member) => sum + member.usageUnits, 0),
   usagePoolLimit: group.planSharingRules.usagePoolLimit,
   outstandingBalance: group.members.reduce((sum, member) => sum + member.outstandingBalance, 0),
+  totalSpend: group.charges.reduce((sum, charge) => sum + charge.amount, 0),
+  memberActivity: group.members.reduce(
+    (activity, member) => ({ ...activity, [member.address]: member.usageUnits }),
+    {}
+  ),
+});
+
+export const updateGroupMemberRole = (
+  group: SubscriptionGroup,
+  memberAddress: string,
+  role: GroupMemberRole
+): SubscriptionGroup => ({
+  ...group,
+  members: group.members.map((member) =>
+    member.address === memberAddress
+      ? {
+          ...member,
+          role,
+          permissions:
+            role === 'admin'
+              ? ['invite', 'remove', 'analytics']
+              : role === 'owner'
+                ? ['invite', 'remove', 'billing', 'analytics']
+                : ['view'],
+        }
+      : member
+  ),
+  updatedAt: new Date(),
 });

--- a/src/store/groupStore.ts
+++ b/src/store/groupStore.ts
@@ -6,8 +6,15 @@ import {
   inviteGroupMember,
   joinGroupWithInvite,
   removeGroupMember,
+  updateGroupMemberRole,
 } from '../services/groupService';
-import { GroupAnalytics, GroupConfig, GroupId, SubscriptionGroup } from '../types/group';
+import {
+  GroupAnalytics,
+  GroupConfig,
+  GroupId,
+  GroupMemberRole,
+  SubscriptionGroup,
+} from '../types/group';
 
 interface GroupState {
   groups: SubscriptionGroup[];
@@ -18,6 +25,7 @@ interface GroupState {
   inviteMember: (groupId: GroupId, inviteeAddress: string, invitedBy: string) => void;
   joinGroup: (groupId: GroupId, inviteId: string, displayName?: string) => void;
   removeMember: (groupId: GroupId, memberAddress: string) => void;
+  updateMemberRole: (groupId: GroupId, memberAddress: string, role: GroupMemberRole) => void;
   chargeGroup: (groupId: GroupId, amount: number) => void;
   getAnalytics: (groupId: GroupId) => GroupAnalytics | undefined;
   selectGroup: (groupId?: GroupId) => void;
@@ -76,6 +84,14 @@ export const useGroupStore = create<GroupState>((set, get) => ({
     } catch (error) {
       set({ error: (error as Error).message });
     }
+  },
+
+  updateMemberRole: (groupId, memberAddress, role) => {
+    set((state) => ({
+      groups: updateGroup(state.groups, groupId, (group) =>
+        updateGroupMemberRole(group, memberAddress, role)
+      ),
+    }));
   },
 
   chargeGroup: (groupId, amount) => {

--- a/src/store/webhookStore.ts
+++ b/src/store/webhookStore.ts
@@ -9,6 +9,7 @@ import {
   WebhookEventType,
   WebhookRetryPolicy,
 } from '../types/webhook';
+import { BillingCycle } from '../types/subscription';
 
 const STORAGE_KEY = 'subtrackr-webhooks';
 const DEFAULT_RETRY_POLICY: WebhookRetryPolicy = {
@@ -35,6 +36,9 @@ const calculateAnalytics = (webhookId: string, deliveries: WebhookDelivery[]): W
   const avgAttempts = totalDeliveries
     ? scoped.reduce((sum, delivery) => sum + delivery.attempts, 0) / totalDeliveries
     : 0;
+  const latencySamples = scoped
+    .map((delivery) => delivery.latencyMs)
+    .filter((latency): latency is number => typeof latency === 'number');
 
   return {
     webhookId,
@@ -45,6 +49,9 @@ const calculateAnalytics = (webhookId: string, deliveries: WebhookDelivery[]): W
     pendingDeliveries,
     successRate: totalDeliveries ? successfulDeliveries / totalDeliveries : 0,
     avgAttempts,
+    avgLatencyMs: latencySamples.length
+      ? latencySamples.reduce((sum, latency) => sum + latency, 0) / latencySamples.length
+      : 0,
     lastSuccessAt: scoped
       .filter((delivery) => delivery.status === 'delivered' && delivery.deliveredAt)
       .map((delivery) => delivery.deliveredAt as number)
@@ -74,6 +81,7 @@ interface WebhookState {
     delivery: Omit<WebhookDelivery, 'id' | 'createdAt' | 'updatedAt'>
   ) => Promise<WebhookDelivery>;
   retryDelivery: (deliveryId: string) => Promise<WebhookDelivery>;
+  sendTestEvent: (webhookId: string, eventType?: WebhookEventType) => Promise<WebhookDelivery>;
   getWebhookDeliveries: (webhookId: string, limit?: number) => WebhookDelivery[];
   getAnalytics: (webhookId: string) => WebhookAnalytics;
   refreshAnalytics: (webhookId?: string) => void;
@@ -192,6 +200,61 @@ export const useWebhookStore = create<WebhookState>()(
         return next;
       },
 
+      sendTestEvent: async (webhookId, eventType = 'subscription.created') => {
+        const webhook = get().webhooks.find((entry) => entry.id === webhookId);
+        if (!webhook) throw new Error(`Webhook ${webhookId} not found`);
+        return get().recordDelivery({
+          webhookId,
+          eventId: createId('evt'),
+          eventType,
+          url: webhook.url,
+          payload: {
+            id: createId('evt'),
+            webhookId,
+            eventType,
+            occurredAt: now(),
+            merchantId: webhook.merchantId,
+            previousStatus: 'none',
+            currentStatus: 'active',
+            payloadVersion: 1,
+            subscription: {
+              id: 'sample_subscription',
+              planId: 'sample_plan',
+              subscriberId: 'sample_customer',
+              status: 'active',
+              startedAt: now(),
+              lastChargedAt: now(),
+              nextChargeAt: now() + 2_592_000_000,
+              totalPaid: 49,
+              totalGasSpent: 0,
+              chargeCount: 1,
+              pausedAt: 0,
+              pauseDuration: 0,
+              refundRequestedAmount: 0,
+            },
+            plan: {
+              id: 'sample_plan',
+              merchantId: webhook.merchantId,
+              name: 'Sample plan',
+              price: 49,
+              token: 'USD',
+              interval: BillingCycle.MONTHLY,
+              active: true,
+              subscriberCount: 1,
+              createdAt: now(),
+            },
+          },
+          status: 'delivered',
+          attempts: 1,
+          maxAttempts: webhook.retryPolicy.maxRetries,
+          deliveredAt: now(),
+          responseCode: 200,
+          signature: 'sample-signature',
+          idempotencyKey: createId('idem'),
+          latencyMs: 120,
+        });
+      },
+
       getWebhookDeliveries: (webhookId, limit = 25) =>
         get()
           .deliveries.filter((delivery) => delivery.webhookId === webhookId)
@@ -240,7 +303,10 @@ export const useWebhookStore = create<WebhookState>()(
 export const webhookEventTypes: WebhookEventType[] = [
   'subscription.created',
   'subscription.updated',
+  'subscription.renewed',
   'subscription.cancelled',
+  'subscription.payment_failed',
+  'subscription.upgraded',
   'subscription.paused',
   'subscription.resumed',
   'subscription.charged',

--- a/src/types/group.ts
+++ b/src/types/group.ts
@@ -6,6 +6,8 @@ export interface GroupMember {
   address: string;
   displayName?: string;
   role: GroupMemberRole;
+  permissions?: string[];
+  paymentMethodId?: string;
   joinedAt: Date;
   outstandingBalance: number;
   usageUnits: number;
@@ -26,6 +28,7 @@ export interface GroupPlanSharingRules {
   usagePoolLimit?: number;
   ownerPaysForMembers: boolean;
   allowMemberOverages: boolean;
+  familyPlanPrice?: number;
 }
 
 export interface GroupBillingLineItem {
@@ -49,6 +52,8 @@ export interface GroupAnalytics {
   totalUsage: number;
   usagePoolLimit?: number;
   outstandingBalance: number;
+  totalSpend: number;
+  memberActivity: Record<string, number>;
 }
 
 export interface GroupConfig {
@@ -63,6 +68,7 @@ export interface SubscriptionGroup {
   members: GroupMember[];
   invites: GroupInvite[];
   planSharingRules: GroupPlanSharingRules;
+  billingAddress?: string;
   charges: GroupChargeResult[];
   createdAt: Date;
   updatedAt: Date;

--- a/src/types/subscription.ts
+++ b/src/types/subscription.ts
@@ -23,6 +23,8 @@ export interface Subscription {
   fiatCurrency?: string;
   fiatPriceUpdatedAt?: Date;
   oraclePriceDeviationBps?: number;
+  groupId?: string;
+  groupMemberAddress?: string;
   timezone?: string;
   createdAt: Date;
   updatedAt: Date;

--- a/src/types/webhook.ts
+++ b/src/types/webhook.ts
@@ -3,7 +3,10 @@ import { BillingCycle } from './subscription';
 export type WebhookEventType =
   | 'subscription.created'
   | 'subscription.updated'
+  | 'subscription.renewed'
   | 'subscription.cancelled'
+  | 'subscription.payment_failed'
+  | 'subscription.upgraded'
   | 'subscription.paused'
   | 'subscription.resumed'
   | 'subscription.charged'
@@ -27,6 +30,7 @@ export interface WebhookConfig {
   events: WebhookEventType[];
   secretKey: string;
   retryPolicy: WebhookRetryPolicy;
+  rateLimitPerMinute?: number;
   isPaused: boolean;
   createdAt: number;
   updatedAt: number;
@@ -129,4 +133,5 @@ export interface WebhookAnalytics {
   avgAttempts: number;
   lastSuccessAt?: number;
   lastFailureAt?: number;
+  avgLatencyMs?: number;
 }


### PR DESCRIPTION
Closes #362  
## analytics: 
added src/services/analyticsService.ts, MRR/ARR/LTV/churn/cohort/forecast metrics in AnalyticsScreen, and backend revenue forecasting helpers in predictionService.ts / churnModel.py.

Closes #363  
## webhooks: 
expanded lifecycle event types, added endpoint rate-limit tracking, latency analytics, and a sample-payload “Send test” action in the webhook store/screen.

Closes #364  
## event sourcing: 
added backend/services/subscriptionEventStore.ts with append-only events, query pagination, reconstruction, replay, and archival; added contract audit event schema in contracts/subscription/src/events.rs.

Closes #365  
## groups/family plans: 
extended group/subscription types for family pricing, member permissions/payment metadata, group spend/activity analytics, store role updates, contract group schema, and a group plan panel in subscription details.