### PR TITLE
fix(#72): improve autoFocus handling on AddSubscriptionScreen

### DIFF
--- a/src/screens/AddSubscriptionScreen.tsx
+++ b/src/screens/AddSubscriptionScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import {
   View,
   Text,
@@ -10,6 +10,7 @@ import {
   Alert,
   KeyboardAvoidingView,
   Platform,
+  Keyboard,
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -33,6 +34,11 @@ const AddSubscriptionScreen: React.FC = () => {
   const { addSubscription, isLoading, error } = useSubscriptionStore();
   const { preferredCurrency } = useSettingsStore();
 
+  // Ref for the name input — used for delayed focus instead of autoFocus,
+  // so the screen has time to fully render before the keyboard opens.
+  const nameInputRef = useRef<TextInput>(null);
+  const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
+
   const [formData, setFormData] = useState<AddSubscriptionFormData>({
     name: '',
     description: '',
@@ -55,6 +61,32 @@ const AddSubscriptionScreen: React.FC = () => {
       // Note: In a real app, you might want to clear errors in the store
     }
   }, [error]);
+
+  // Delay focus so the screen finishes rendering before the keyboard opens.
+  // A 300 ms delay gives the navigation transition time to complete on both
+  // iOS and Android, preventing the keyboard from obscuring UI elements.
+  useEffect(() => {
+    const focusTimer = setTimeout(() => {
+      nameInputRef.current?.focus();
+    }, 300);
+
+    return () => clearTimeout(focusTimer);
+  }, []);
+
+  // Track keyboard visibility so the ScrollView can adjust its content
+  // inset and keep form fields accessible when the keyboard is open.
+  useEffect(() => {
+    const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+    const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+
+    const showSub = Keyboard.addListener(showEvent, () => setIsKeyboardVisible(true));
+    const hideSub = Keyboard.addListener(hideEvent, () => setIsKeyboardVisible(false));
+
+    return () => {
+      showSub.remove();
+      hideSub.remove();
+    };
+  }, []);
 
   // Date Picker States
   const [showPicker, setShowPicker] = useState(false);
@@ -186,8 +218,12 @@ const AddSubscriptionScreen: React.FC = () => {
     <SafeAreaView style={styles.container} testID="add-subscription-screen">
       <KeyboardAvoidingView
         style={styles.keyboardAvoidingView}
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
-        <ScrollView style={styles.scrollView} keyboardShouldPersistTaps="handled">
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 0}>
+        <ScrollView
+          style={styles.scrollView}
+          keyboardShouldPersistTaps="handled"
+          contentContainerStyle={isKeyboardVisible ? styles.scrollContentKeyboardOpen : undefined}>
           <View style={styles.header}>
             <View style={styles.headerContent}>
               <TouchableOpacity
@@ -210,12 +246,12 @@ const AddSubscriptionScreen: React.FC = () => {
               <View style={styles.inputGroup}>
                 <Text style={styles.label}>Name *</Text>
                 <TextInput
+                  ref={nameInputRef}
                   style={styles.textInput}
                   value={formData.name}
                   onChangeText={(text) => handleInputChange('name', text)}
                   placeholder="Enter subscription name"
                   placeholderTextColor={colors.textSecondary}
-                  autoFocus
                   accessibilityLabel="Subscription name, required"
                   accessibilityHint="Enter the name of the subscription service"
                   returnKeyType="next"
@@ -479,6 +515,9 @@ const styles = StyleSheet.create({
   },
   scrollView: {
     flex: 1,
+  },
+  scrollContentKeyboardOpen: {
+    paddingBottom: 120,
   },
   header: {
     padding: spacing.lg,


### PR DESCRIPTION
## Summary

Closes #72

The `autoFocus` prop on the subscription name input caused the keyboard to open immediately on mount, blocking UI elements before the screen finished rendering — especially noticeable during the navigation transition on Android.

## Changes

### Commit 1 — Replace `autoFocus` with delayed focus via `useRef`
- Added `nameInputRef` (`useRef<TextInput>`) to the name field
- Removed the `autoFocus` prop from the name `TextInput`
- Focus is now triggered programmatically after a **300 ms delay** in a `useEffect`, giving the navigation transition time to complete on both platforms
- Imported `useRef` from React

### Commit 2 — Improve `KeyboardAvoidingView` and keyboard visibility tracking
- Switched `KeyboardAvoidingView` behavior to `'padding'` on iOS and `undefined` on Android (Android's scroll container handles this natively)
- Added `Keyboard` listeners (`keyboardWillShow`/`keyboardDidShow` and their hide counterparts) to track `isKeyboardVisible` state
- Applied extra bottom padding to the `ScrollView` content when the keyboard is open, keeping all form fields reachable
- Imported `Keyboard` from `react-native`

## Acceptance Criteria

- [x] UI is fully visible when the screen opens (keyboard does not immediately block elements)
- [x] Keyboard still opens automatically after the screen renders — user can still focus the field
- [x] `KeyboardAvoidingView` behaves correctly on iOS (`padding`) and Android (native scroll)
- [x] Form fields remain accessible when keyboard is open (extra scroll padding)
- [x] Works on both iOS and Android

## Testing

Tested manually on:
- iOS Simulator (iPhone 15, iOS 17)
- Android Emulator (Pixel 7, API 34)