### PR TITLE
feat: implement calendar-based billing scheduling (#182)

### DIFF
--- a/app/screens/BillingSettingsScreen.tsx
+++ b/app/screens/BillingSettingsScreen.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../src/screens/BillingSettingsScreen';

--- a/app/stores/billingStore.ts
+++ b/app/stores/billingStore.ts
@@ -1,0 +1,1 @@
+export * from '../../src/store/billingStore';

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -48,6 +48,7 @@ import ApiKeyManagementScreen from '../screens/ApiKeyManagementScreen';
 import DocumentationPortalScreen from '../screens/DocumentationPortalScreen';
 import IntegrationGuidesScreen from '../screens/IntegrationGuidesScreen';
 import PerformanceDashboardScreen from '../screens/PerformanceDashboardScreen';
+import BillingSettingsScreen from '../screens/BillingSettingsScreen';
 import { colors } from '../utils/constants';
 
 import { RootStackParamList, TabParamList } from './types';
@@ -303,6 +304,11 @@ const SettingsStack = () => (
       name="PerformanceDashboard"
       component={PerformanceDashboardScreen}
       options={{ title: 'Performance', headerShown: true }}
+    />
+    <Stack.Screen
+      name="BillingSettings"
+      component={BillingSettingsScreen}
+      options={{ title: 'Billing Settings', headerShown: true }}
     />
   </Stack.Navigator>
 );

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -43,6 +43,7 @@ export type RootStackParamList = {
   LoyaltyDashboard: undefined;
   CampaignManagement: undefined;
   PerformanceDashboard: undefined;
+  BillingSettings: undefined;
 };
 
 export type TabParamList = {

--- a/src/screens/BillingSettingsScreen.tsx
+++ b/src/screens/BillingSettingsScreen.tsx
@@ -1,0 +1,707 @@
+import DateTimePicker from '@react-native-community/datetimepicker';
+import React, { useCallback, useState } from 'react';
+import {
+  Alert,
+  Platform,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { Card } from '../components/common/Card';
+import { useBillingStore } from '../store/billingStore';
+import type { AdjustmentPolicy, CalendarBilling } from '../types/calendar';
+import { borderRadius, colors, spacing, typography } from '../utils/constants';
+import { normalizeBillingDay } from '../services/calendarService';
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+const ADJUSTMENT_POLICY_OPTIONS: { value: AdjustmentPolicy; label: string; description: string }[] =
+  [
+    {
+      value: 'last_day',
+      label: 'Last day of month',
+      description: 'Bill on the last valid day (e.g. Jan 31 → Feb 28/29)',
+    },
+    {
+      value: 'first_day_next',
+      label: 'First of next month',
+      description: 'Roll over to the 1st of the following month',
+    },
+    {
+      value: 'skip',
+      label: 'Skip short months',
+      description: 'Skip billing entirely for months without the target day',
+    },
+  ];
+
+const INTERVAL_OPTIONS: { value: number; label: string }[] = [
+  { value: 1, label: 'Monthly' },
+  { value: 2, label: 'Every 2 months' },
+  { value: 3, label: 'Quarterly' },
+  { value: 6, label: 'Semi-annually' },
+  { value: 12, label: 'Annually' },
+];
+
+const DAY_OPTIONS = Array.from({ length: 31 }, (_, i) => i + 1);
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function ordinal(n: number): string {
+  const s = ['th', 'st', 'nd', 'rd'];
+  const v = n % 100;
+  return n + (s[(v - 20) % 10] ?? s[v] ?? s[0]);
+}
+
+function formatBillingDate(isoString: string): string {
+  return new Date(isoString).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+// ── Default config ─────────────────────────────────────────────────────────
+
+const DEFAULT_CONFIG: CalendarBilling = {
+  day_of_month: 1,
+  billing_months_interval: 1,
+  adjustment_policy: 'last_day',
+  timezone: 'UTC',
+};
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+/**
+ * BillingSettingsScreen
+ *
+ * Allows a merchant to configure calendar-based billing:
+ * - Choose the day of month to bill on
+ * - Choose the billing interval (monthly, quarterly, etc.)
+ * - Choose how to handle months with fewer days
+ * - Preview the next billing date
+ * - View generated invoices
+ */
+const BillingSettingsScreen: React.FC = () => {
+  // For demo purposes we use a fixed merchantId; in production this would
+  // come from an auth store or route params.
+  const MERCHANT_ID = 'merchant_default';
+
+  const {
+    schedules,
+    invoices,
+    setMerchantCalendarBilling,
+    removeMerchantCalendarBilling,
+    advanceSchedule,
+    generateInvoice,
+    updateInvoiceStatus,
+    getInvoicesForMerchant,
+    calculateProRata,
+    error,
+    clearError,
+  } = useBillingStore();
+
+  const existingSchedule = schedules[MERCHANT_ID];
+  const merchantInvoices = getInvoicesForMerchant(MERCHANT_ID);
+
+  // ── Local form state ───────────────────────────────────────────────────
+
+  const [config, setConfig] = useState<CalendarBilling>(
+    existingSchedule?.config ?? DEFAULT_CONFIG
+  );
+  const [showDayPicker, setShowDayPicker] = useState(false);
+  const [showProRataDemo, setShowProRataDemo] = useState(false);
+  const [proRataJoinDate, setProRataJoinDate] = useState(new Date());
+  const [showDatePicker, setShowDatePicker] = useState(false);
+
+  // ── Handlers ───────────────────────────────────────────────────────────
+
+  const handleSave = useCallback(() => {
+    if (config.day_of_month < 1 || config.day_of_month > 31) {
+      Alert.alert('Invalid day', 'Day of month must be between 1 and 31.');
+      return;
+    }
+    setMerchantCalendarBilling(MERCHANT_ID, config);
+    Alert.alert('Saved', 'Calendar billing schedule has been updated.');
+  }, [config, setMerchantCalendarBilling]);
+
+  const handleRemove = useCallback(() => {
+    Alert.alert(
+      'Remove schedule',
+      'Are you sure you want to remove the calendar billing schedule?',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Remove',
+          style: 'destructive',
+          onPress: () => {
+            removeMerchantCalendarBilling(MERCHANT_ID);
+            setConfig(DEFAULT_CONFIG);
+            Alert.alert('Removed', 'Calendar billing schedule removed.');
+          },
+        },
+      ]
+    );
+  }, [removeMerchantCalendarBilling]);
+
+  const handleGenerateDemoInvoice = useCallback(() => {
+    if (!existingSchedule) {
+      Alert.alert('No schedule', 'Save a billing schedule first.');
+      return;
+    }
+    const now = new Date();
+    const billingDate = new Date(existingSchedule.nextBillingDate);
+    // Period: from today to billing date
+    const invoice = generateInvoice({
+      subscriptionId: 'sub_demo',
+      merchantId: MERCHANT_ID,
+      periodStart: now,
+      periodEnd: billingDate,
+      billingDate,
+      amount: 99.99,
+      currency: 'USD',
+    });
+    Alert.alert(
+      'Invoice generated',
+      `Invoice ${invoice.id}\nPeriod: ${formatBillingDate(invoice.periodStart)} → ${formatBillingDate(invoice.periodEnd)}\nAmount: ${invoice.currency} ${invoice.amount.toFixed(2)}`
+    );
+  }, [existingSchedule, generateInvoice]);
+
+  const handleAdvanceSchedule = useCallback(() => {
+    if (!existingSchedule) {
+      Alert.alert('No schedule', 'Save a billing schedule first.');
+      return;
+    }
+    advanceSchedule(MERCHANT_ID);
+    Alert.alert('Advanced', 'Schedule moved to the next billing period.');
+  }, [existingSchedule, advanceSchedule]);
+
+  const handleProRataDemo = useCallback(() => {
+    if (!existingSchedule) {
+      Alert.alert('No schedule', 'Save a billing schedule first.');
+      return;
+    }
+    const periodStart = new Date();
+    periodStart.setDate(1); // Start of current month
+    const periodEnd = new Date(existingSchedule.nextBillingDate);
+    const proRata = calculateProRata(99.99, periodStart, periodEnd, proRataJoinDate);
+    Alert.alert(
+      'Pro-rata calculation',
+      `Full amount: $99.99\nJoin date: ${proRataJoinDate.toLocaleDateString()}\nPro-rated charge: $${proRata.toFixed(2)}`
+    );
+  }, [existingSchedule, proRataJoinDate, calculateProRata]);
+
+  // ── Render ─────────────────────────────────────────────────────────────
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content}>
+        {/* Header */}
+        <View style={styles.header}>
+          <Text style={styles.title}>Billing Settings</Text>
+          <Text style={styles.subtitle}>
+            Configure calendar-based billing to align charges with your accounting periods.
+          </Text>
+        </View>
+
+        {/* Error banner */}
+        {error ? (
+          <Card style={styles.errorCard}>
+            <Text style={styles.errorText}>{error}</Text>
+            <TouchableOpacity style={styles.errorButton} onPress={clearError}>
+              <Text style={styles.errorButtonText}>Dismiss</Text>
+            </TouchableOpacity>
+          </Card>
+        ) : null}
+
+        {/* Current schedule summary */}
+        {existingSchedule ? (
+          <Card style={styles.section}>
+            <Text style={styles.sectionTitle}>Active schedule</Text>
+            <View style={styles.metricRow}>
+              <Text style={styles.metricLabel}>Billing day</Text>
+              <Text style={styles.metricValue}>{ordinal(existingSchedule.config.day_of_month)}</Text>
+            </View>
+            <View style={styles.metricRow}>
+              <Text style={styles.metricLabel}>Interval</Text>
+              <Text style={styles.metricValue}>
+                {INTERVAL_OPTIONS.find((o) => o.value === existingSchedule.config.billing_months_interval)?.label ?? `Every ${existingSchedule.config.billing_months_interval} months`}
+              </Text>
+            </View>
+            <View style={styles.metricRow}>
+              <Text style={styles.metricLabel}>Short-month policy</Text>
+              <Text style={styles.metricValue}>
+                {ADJUSTMENT_POLICY_OPTIONS.find((o) => o.value === existingSchedule.config.adjustment_policy)?.label}
+              </Text>
+            </View>
+            <View style={[styles.metricRow, styles.highlightRow]}>
+              <Text style={styles.metricLabel}>Next billing date</Text>
+              <Text style={[styles.metricValue, styles.highlightValue]}>
+                {formatBillingDate(existingSchedule.nextBillingDate)}
+              </Text>
+            </View>
+          </Card>
+        ) : null}
+
+        {/* Day of month picker */}
+        <Card style={styles.section}>
+          <Text style={styles.sectionTitle}>Day of month</Text>
+          <Text style={styles.sectionDescription}>
+            Choose which calendar day billing occurs on each period.
+          </Text>
+          <TouchableOpacity
+            style={styles.selectorButton}
+            onPress={() => setShowDayPicker((v) => !v)}>
+            <Text style={styles.selectorButtonText}>
+              {ordinal(config.day_of_month)} of the month
+            </Text>
+            <Text style={styles.chevron}>{showDayPicker ? '▲' : '▼'}</Text>
+          </TouchableOpacity>
+
+          {showDayPicker ? (
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              style={styles.dayScroll}>
+              {DAY_OPTIONS.map((day) => (
+                <TouchableOpacity
+                  key={day}
+                  style={[styles.dayChip, day === config.day_of_month && styles.dayChipActive]}
+                  onPress={() => {
+                    setConfig((c) => ({ ...c, day_of_month: day }));
+                    setShowDayPicker(false);
+                  }}>
+                  <Text
+                    style={[
+                      styles.dayChipText,
+                      day === config.day_of_month && styles.dayChipTextActive,
+                    ]}>
+                    {day}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </ScrollView>
+          ) : null}
+
+          {config.day_of_month > 28 ? (
+            <View style={styles.warningBanner}>
+              <Text style={styles.warningText}>
+                ⚠️ Day {config.day_of_month} doesn't exist in all months. The short-month policy
+                below controls how this is handled.
+              </Text>
+            </View>
+          ) : null}
+        </Card>
+
+        {/* Billing interval */}
+        <Card style={styles.section}>
+          <Text style={styles.sectionTitle}>Billing interval</Text>
+          <Text style={styles.sectionDescription}>How often billing occurs.</Text>
+          <View style={styles.optionGrid}>
+            {INTERVAL_OPTIONS.map((option) => {
+              const selected = config.billing_months_interval === option.value;
+              return (
+                <TouchableOpacity
+                  key={option.value}
+                  style={[styles.optionChip, selected && styles.optionChipActive]}
+                  onPress={() =>
+                    setConfig((c) => ({ ...c, billing_months_interval: option.value }))
+                  }>
+                  <Text style={[styles.optionChipText, selected && styles.optionChipTextActive]}>
+                    {option.label}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+        </Card>
+
+        {/* Adjustment policy */}
+        <Card style={styles.section}>
+          <Text style={styles.sectionTitle}>Short-month handling</Text>
+          <Text style={styles.sectionDescription}>
+            What to do when the billing day doesn't exist in a given month (e.g. Jan 31 → Feb).
+          </Text>
+          {ADJUSTMENT_POLICY_OPTIONS.map((option) => {
+            const selected = config.adjustment_policy === option.value;
+            return (
+              <TouchableOpacity
+                key={option.value}
+                style={[styles.policyCard, selected && styles.policyCardActive]}
+                onPress={() => setConfig((c) => ({ ...c, adjustment_policy: option.value }))}>
+                <View style={styles.policyRow}>
+                  <View style={[styles.radioOuter, selected && styles.radioOuterActive]}>
+                    {selected ? <View style={styles.radioInner} /> : null}
+                  </View>
+                  <View style={styles.policyText}>
+                    <Text style={[styles.policyLabel, selected && styles.policyLabelActive]}>
+                      {option.label}
+                    </Text>
+                    <Text style={styles.policyDescription}>{option.description}</Text>
+                  </View>
+                </View>
+              </TouchableOpacity>
+            );
+          })}
+        </Card>
+
+        {/* Edge case examples */}
+        <Card style={styles.section}>
+          <Text style={styles.sectionTitle}>Edge case examples</Text>
+          <Text style={styles.sectionDescription}>
+            How your current settings handle common edge cases.
+          </Text>
+          {[
+            { label: 'Jan 31 → Feb', month: 2, year: 2025 },
+            { label: 'Feb 29 (non-leap)', month: 2, year: 2025 },
+            { label: 'Feb 29 (leap year)', month: 2, year: 2024 },
+            { label: 'Mar 31 → Apr', month: 4, year: 2025 },
+          ].map((example) => {
+            const result = normalizeBillingDay(
+              config.day_of_month,
+              example.month,
+              example.year,
+              config.adjustment_policy
+            );
+
+            const resultStr = result
+              ? new Date(Date.UTC(result.year, result.month - 1, result.day)).toLocaleDateString(
+                  'en-US',
+                  { month: 'short', day: 'numeric', year: 'numeric' }
+                )
+              : 'Skipped';
+
+            return (
+              <View key={example.label} style={styles.exampleRow}>
+                <Text style={styles.exampleLabel}>{example.label}</Text>
+                <Text style={[styles.exampleResult, result === null && styles.exampleSkipped]}>
+                  {resultStr}
+                </Text>
+              </View>
+            );
+          })}
+        </Card>
+
+        {/* Save / Remove actions */}
+        <Card style={styles.section}>
+          <Text style={styles.sectionTitle}>Actions</Text>
+          <TouchableOpacity style={styles.primaryButton} onPress={handleSave}>
+            <Text style={styles.primaryButtonText}>
+              {existingSchedule ? 'Update schedule' : 'Save schedule'}
+            </Text>
+          </TouchableOpacity>
+
+          {existingSchedule ? (
+            <>
+              <TouchableOpacity
+                style={[styles.primaryButton, styles.secondaryButton]}
+                onPress={handleAdvanceSchedule}>
+                <Text style={styles.secondaryButtonText}>Advance to next period</Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                style={[styles.primaryButton, styles.dangerButton]}
+                onPress={handleRemove}>
+                <Text style={styles.primaryButtonText}>Remove schedule</Text>
+              </TouchableOpacity>
+            </>
+          ) : null}
+        </Card>
+
+        {/* Invoice generation demo */}
+        <Card style={styles.section}>
+          <Text style={styles.sectionTitle}>Invoice generation</Text>
+          <Text style={styles.sectionDescription}>
+            Generate a draft invoice for the current billing period.
+          </Text>
+          <TouchableOpacity style={styles.primaryButton} onPress={handleGenerateDemoInvoice}>
+            <Text style={styles.primaryButtonText}>Generate demo invoice</Text>
+          </TouchableOpacity>
+
+          {merchantInvoices.length > 0 ? (
+            <View style={styles.invoiceList}>
+              {merchantInvoices.slice(0, 5).map((inv) => (
+                <View key={inv.id} style={styles.invoiceRow}>
+                  <View style={styles.invoiceInfo}>
+                    <Text style={styles.invoiceId}>{inv.id}</Text>
+                    <Text style={styles.invoicePeriod}>
+                      {formatBillingDate(inv.periodStart)} → {formatBillingDate(inv.periodEnd)}
+                    </Text>
+                    {inv.isProratedPeriod && inv.proratedAmount != null ? (
+                      <Text style={styles.invoiceProRata}>
+                        Pro-rated: {inv.currency} {inv.proratedAmount.toFixed(2)} (of{' '}
+                        {inv.amount.toFixed(2)})
+                      </Text>
+                    ) : null}
+                  </View>
+                  <View style={styles.invoiceActions}>
+                    <Text style={[styles.invoiceStatus, styles[`status_${inv.status}`]]}>
+                      {inv.status}
+                    </Text>
+                    {inv.status === 'draft' ? (
+                      <TouchableOpacity
+                        style={styles.issueButton}
+                        onPress={() => updateInvoiceStatus(inv.id, 'issued')}>
+                        <Text style={styles.issueButtonText}>Issue</Text>
+                      </TouchableOpacity>
+                    ) : null}
+                  </View>
+                </View>
+              ))}
+            </View>
+          ) : (
+            <Text style={styles.emptyText}>No invoices yet.</Text>
+          )}
+        </Card>
+
+        {/* Pro-rata demo */}
+        <Card style={styles.section}>
+          <Text style={styles.sectionTitle}>Pro-rata calculator</Text>
+          <Text style={styles.sectionDescription}>
+            Preview the pro-rated charge for a mid-period subscription start.
+          </Text>
+
+          <Text style={styles.fieldLabel}>Subscription join date</Text>
+          <TouchableOpacity
+            style={styles.selectorButton}
+            onPress={() => setShowDatePicker(true)}>
+            <Text style={styles.selectorButtonText}>
+              {proRataJoinDate.toLocaleDateString('en-US', {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+              })}
+            </Text>
+          </TouchableOpacity>
+
+          {showDatePicker ? (
+            <DateTimePicker
+              value={proRataJoinDate}
+              mode="date"
+              display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+              onChange={(_event, date) => {
+                setShowDatePicker(Platform.OS === 'ios');
+                if (date) setProRataJoinDate(date);
+              }}
+            />
+          ) : null}
+
+          <TouchableOpacity
+            style={[styles.primaryButton, { marginTop: spacing.md }]}
+            onPress={handleProRataDemo}>
+            <Text style={styles.primaryButtonText}>Calculate pro-rata</Text>
+          </TouchableOpacity>
+        </Card>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+// ── Styles ─────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: colors.background },
+  content: { padding: spacing.lg, gap: spacing.md },
+  header: { marginBottom: spacing.sm },
+  title: { ...typography.h1, color: colors.text, marginBottom: spacing.xs },
+  subtitle: { ...typography.body, color: colors.textSecondary },
+  section: { padding: spacing.lg },
+  sectionTitle: { ...typography.h3, color: colors.text, marginBottom: spacing.sm },
+  sectionDescription: {
+    ...typography.caption,
+    color: colors.textSecondary,
+    marginBottom: spacing.md,
+  },
+  metricRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: spacing.sm,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  highlightRow: {
+    borderBottomWidth: 0,
+    marginTop: spacing.xs,
+  },
+  metricLabel: { ...typography.body, color: colors.textSecondary },
+  metricValue: { ...typography.body, color: colors.text, fontWeight: '600' },
+  highlightValue: { color: colors.primary, ...typography.h3 },
+  selectorButton: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: borderRadius.md,
+    padding: spacing.md,
+    backgroundColor: colors.surface,
+  },
+  selectorButtonText: { ...typography.body, color: colors.text },
+  chevron: { ...typography.body, color: colors.textSecondary },
+  dayScroll: { marginTop: spacing.md },
+  dayChip: {
+    width: 40,
+    height: 40,
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.surface,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: spacing.xs,
+  },
+  dayChipActive: {
+    borderColor: colors.primary,
+    backgroundColor: `${colors.primary}22`,
+  },
+  dayChipText: { ...typography.caption, color: colors.textSecondary, fontWeight: '600' },
+  dayChipTextActive: { color: colors.text },
+  warningBanner: {
+    marginTop: spacing.md,
+    padding: spacing.md,
+    borderRadius: borderRadius.md,
+    backgroundColor: colors.warningBackground,
+    borderWidth: 1,
+    borderColor: `${colors.warning}44`,
+  },
+  warningText: { ...typography.caption, color: colors.warning },
+  optionGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+  },
+  optionChip: {
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderRadius: borderRadius.full,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.surface,
+  },
+  optionChipActive: {
+    borderColor: colors.primary,
+    backgroundColor: `${colors.primary}22`,
+  },
+  optionChipText: { ...typography.caption, color: colors.textSecondary, fontWeight: '600' },
+  optionChipTextActive: { color: colors.text },
+  policyCard: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: borderRadius.lg,
+    padding: spacing.md,
+    marginBottom: spacing.sm,
+    backgroundColor: colors.surface,
+  },
+  policyCardActive: {
+    borderColor: colors.primary,
+    backgroundColor: `${colors.primary}14`,
+  },
+  policyRow: { flexDirection: 'row', alignItems: 'flex-start', gap: spacing.md },
+  radioOuter: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    borderWidth: 2,
+    borderColor: colors.border,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 2,
+  },
+  radioOuterActive: { borderColor: colors.primary },
+  radioInner: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    backgroundColor: colors.primary,
+  },
+  policyText: { flex: 1 },
+  policyLabel: { ...typography.body, color: colors.text, fontWeight: '600' },
+  policyLabelActive: { color: colors.text },
+  policyDescription: { ...typography.caption, color: colors.textSecondary, marginTop: spacing.xs },
+  exampleRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: spacing.sm,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  exampleLabel: { ...typography.caption, color: colors.textSecondary },
+  exampleResult: { ...typography.caption, color: colors.text, fontWeight: '600' },
+  exampleSkipped: { color: colors.warning },
+  primaryButton: {
+    backgroundColor: colors.primary,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.lg,
+    borderRadius: borderRadius.md,
+    alignItems: 'center',
+    marginBottom: spacing.sm,
+  },
+  primaryButtonText: { ...typography.button, color: colors.onPrimary, fontWeight: '700' },
+  secondaryButton: {
+    backgroundColor: colors.surfaceVariant,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  secondaryButtonText: { ...typography.button, color: colors.text, fontWeight: '600' },
+  dangerButton: { backgroundColor: colors.error },
+  fieldLabel: {
+    ...typography.caption,
+    color: colors.textSecondary,
+    marginBottom: spacing.sm,
+    fontWeight: '600',
+  },
+  invoiceList: { marginTop: spacing.md, gap: spacing.sm },
+  invoiceRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    paddingVertical: spacing.sm,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+    gap: spacing.sm,
+  },
+  invoiceInfo: { flex: 1, gap: spacing.xs },
+  invoiceId: { ...typography.small, color: colors.textSecondary, fontFamily: 'monospace' },
+  invoicePeriod: { ...typography.caption, color: colors.text },
+  invoiceProRata: { ...typography.small, color: colors.accent },
+  invoiceActions: { alignItems: 'flex-end', gap: spacing.xs },
+  invoiceStatus: { ...typography.small, fontWeight: '700', textTransform: 'uppercase' },
+  status_draft: { color: colors.textSecondary },
+  status_issued: { color: colors.accent },
+  status_paid: { color: colors.success },
+  status_void: { color: colors.error },
+  issueButton: {
+    paddingVertical: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    borderRadius: borderRadius.sm,
+    backgroundColor: `${colors.accent}22`,
+    borderWidth: 1,
+    borderColor: colors.accent,
+  },
+  issueButtonText: { ...typography.small, color: colors.accent, fontWeight: '600' },
+  emptyText: { ...typography.caption, color: colors.textSecondary, marginTop: spacing.sm },
+  errorCard: {
+    borderWidth: 1,
+    borderColor: `${colors.error}66`,
+    backgroundColor: `${colors.error}12`,
+    gap: spacing.md,
+    padding: spacing.md,
+  },
+  errorText: { ...typography.caption, color: colors.error },
+  errorButton: {
+    alignSelf: 'flex-start',
+    paddingVertical: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    borderColor: `${colors.error}66`,
+  },
+  errorButtonText: { ...typography.caption, color: colors.error, fontWeight: '600' },
+});
+
+export default BillingSettingsScreen;

--- a/src/services/calendarService.ts
+++ b/src/services/calendarService.ts
@@ -478,3 +478,210 @@ export function adjustForDST(event: CalendarEventTemplate, timezone: string): Ca
   }
   return event;
 }
+
+// ── Calendar-Based Billing ─────────────────────────────────────────────────
+
+import type { AdjustmentPolicy, CalendarBilling, CalendarInvoice, MerchantBillingSchedule } from '../types/calendar';
+
+/**
+ * Returns the number of days in a given month/year pair.
+ * Correctly handles leap years for February.
+ */
+export function daysInMonth(year: number, month: number): number {
+  // month is 1-indexed (1 = January, 12 = December)
+  return new Date(year, month, 0).getDate();
+}
+
+/**
+ * Normalize a target day_of_month to a valid day for the given year/month,
+ * applying the adjustment_policy when the month has fewer days.
+ *
+ * Examples:
+ *   normalizeBillingDay(31, 2, 2023, 'last_day')       → 28
+ *   normalizeBillingDay(31, 2, 2024, 'last_day')        → 29  (leap year)
+ *   normalizeBillingDay(31, 2, 2023, 'first_day_next')  → 1  (March 1)
+ *   normalizeBillingDay(31, 2, 2023, 'skip')            → null (skip this month)
+ *
+ * Returns { year, month, day } or null when policy is 'skip'.
+ */
+export function normalizeBillingDay(
+  targetDay: number,
+  month: number,
+  year: number,
+  policy: AdjustmentPolicy
+): { year: number; month: number; day: number } | null {
+  const maxDay = daysInMonth(year, month);
+
+  if (targetDay <= maxDay) {
+    return { year, month, day: targetDay };
+  }
+
+  // Target day exceeds days in this month — apply policy
+  switch (policy) {
+    case 'last_day':
+      return { year, month, day: maxDay };
+
+    case 'first_day_next': {
+      // Roll over to the 1st of the next month
+      const nextMonth = month === 12 ? 1 : month + 1;
+      const nextYear = month === 12 ? year + 1 : year;
+      return { year: nextYear, month: nextMonth, day: 1 };
+    }
+
+    case 'skip':
+      return null;
+
+    default:
+      return { year, month, day: maxDay };
+  }
+}
+
+/**
+ * Calculate the next billing date given a CalendarBilling config and a reference date.
+ *
+ * The algorithm:
+ * 1. Start from the month of `current` (or the next month if we've already passed
+ *    the target day this month).
+ * 2. Advance by billing_months_interval months.
+ * 3. Apply normalizeBillingDay to handle short months.
+ * 4. If policy is 'skip' and the result is null, advance one more interval and retry.
+ */
+export function calculateNextBillingDate(current: Date, config: CalendarBilling): Date {
+  const { day_of_month, billing_months_interval, adjustment_policy, timezone } = config;
+
+  // Work in the configured timezone by using a locale string to extract y/m/d
+  const tz = timezone ?? 'UTC';
+  const localStr = current.toLocaleDateString('en-CA', { timeZone: tz }); // 'YYYY-MM-DD'
+  const [yearStr, monthStr, dayStr] = localStr.split('-');
+  const currentYear = parseInt(yearStr, 10);
+  const currentMonth = parseInt(monthStr, 10); // 1-indexed
+  const currentDay = parseInt(dayStr, 10);
+
+  // Determine the starting month: if we haven't yet reached day_of_month this month,
+  // the next billing date could be this month; otherwise start from next interval.
+  let candidateYear = currentYear;
+  let candidateMonth = currentMonth;
+
+  if (currentDay >= day_of_month) {
+    // Already at or past the billing day — advance by one interval
+    candidateMonth += billing_months_interval;
+    while (candidateMonth > 12) {
+      candidateMonth -= 12;
+      candidateYear += 1;
+    }
+  }
+
+  // Try up to 24 months to find a non-skipped date
+  for (let attempt = 0; attempt < 24; attempt++) {
+    const normalized = normalizeBillingDay(day_of_month, candidateMonth, candidateYear, adjustment_policy);
+
+    if (normalized !== null) {
+      // Build a Date at midnight UTC on the normalized date
+      return new Date(Date.UTC(normalized.year, normalized.month - 1, normalized.day, 0, 0, 0));
+    }
+
+    // Policy is 'skip' — advance by one more interval
+    candidateMonth += billing_months_interval;
+    while (candidateMonth > 12) {
+      candidateMonth -= 12;
+      candidateYear += 1;
+    }
+  }
+
+  // Fallback: should never reach here with valid config
+  return new Date(Date.UTC(candidateYear, candidateMonth - 1, day_of_month, 0, 0, 0));
+}
+
+/**
+ * Calculate a pro-rata amount for a subscription that starts mid-billing-period.
+ *
+ * @param fullAmount   The full period charge.
+ * @param periodStart  Start of the billing period.
+ * @param periodEnd    End of the billing period.
+ * @param joinDate     The date the subscription actually started.
+ * @returns            The pro-rated amount (rounded to 2 decimal places).
+ */
+export function calculateProRataAmount(
+  fullAmount: number,
+  periodStart: Date,
+  periodEnd: Date,
+  joinDate: Date
+): number {
+  const totalMs = periodEnd.getTime() - periodStart.getTime();
+  if (totalMs <= 0) return fullAmount;
+
+  const effectiveStart = joinDate > periodStart ? joinDate : periodStart;
+  const remainingMs = periodEnd.getTime() - effectiveStart.getTime();
+  if (remainingMs <= 0) return 0;
+
+  const ratio = Math.min(remainingMs / totalMs, 1);
+  return Number((fullAmount * ratio).toFixed(2));
+}
+
+/**
+ * Generate an invoice for a subscription billing period.
+ */
+export function generateCalendarInvoice(
+  subscriptionId: string,
+  merchantId: string,
+  periodStart: Date,
+  periodEnd: Date,
+  billingDate: Date,
+  amount: number,
+  currency: string,
+  joinDate?: Date
+): CalendarInvoice {
+  const isProratedPeriod = joinDate != null && joinDate > periodStart;
+  const proratedAmount = isProratedPeriod && joinDate
+    ? calculateProRataAmount(amount, periodStart, periodEnd, joinDate)
+    : undefined;
+
+  return {
+    id: `inv_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`,
+    subscriptionId,
+    merchantId,
+    periodStart: periodStart.toISOString(),
+    periodEnd: periodEnd.toISOString(),
+    billingDate: billingDate.toISOString(),
+    amount,
+    currency,
+    proratedAmount,
+    isProratedPeriod,
+    status: 'draft',
+    createdAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Create or update a merchant billing schedule.
+ */
+export function setCalendarBilling(
+  merchantId: string,
+  config: CalendarBilling,
+  referenceDate: Date = new Date()
+): MerchantBillingSchedule {
+  const nextBillingDate = calculateNextBillingDate(referenceDate, config);
+  const now = new Date().toISOString();
+  return {
+    merchantId,
+    config,
+    nextBillingDate: nextBillingDate.toISOString(),
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+/**
+ * Advance a MerchantBillingSchedule to the next period after a successful charge.
+ */
+export function advanceMerchantBillingSchedule(
+  schedule: MerchantBillingSchedule
+): MerchantBillingSchedule {
+  const current = new Date(schedule.nextBillingDate);
+  const next = calculateNextBillingDate(current, schedule.config);
+  return {
+    ...schedule,
+    nextBillingDate: next.toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}

--- a/src/store/billingStore.ts
+++ b/src/store/billingStore.ts
@@ -1,0 +1,206 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+import {
+  advanceMerchantBillingSchedule,
+  calculateNextBillingDate,
+  calculateProRataAmount,
+  generateCalendarInvoice,
+  setCalendarBilling,
+} from '../services/calendarService';
+import type {
+  AdjustmentPolicy,
+  CalendarBilling,
+  CalendarInvoice,
+  MerchantBillingSchedule,
+} from '../types/calendar';
+
+const STORAGE_KEY = 'subtrackr-billing-schedules';
+
+// ── State shape ────────────────────────────────────────────────────────────
+
+interface BillingState {
+  /** Per-merchant calendar billing schedules, keyed by merchantId. */
+  schedules: Record<string, MerchantBillingSchedule>;
+  /** Generated invoices, keyed by invoice id. */
+  invoices: Record<string, CalendarInvoice>;
+  isLoading: boolean;
+  error: string | null;
+
+  // ── Actions ──────────────────────────────────────────────────────────────
+
+  /**
+   * Create or replace the calendar billing config for a merchant.
+   * Immediately calculates the next billing date from today.
+   */
+  setMerchantCalendarBilling: (merchantId: string, config: CalendarBilling) => void;
+
+  /**
+   * Remove a merchant's calendar billing schedule.
+   */
+  removeMerchantCalendarBilling: (merchantId: string) => void;
+
+  /**
+   * Get the next billing date for a merchant given their current config.
+   * Returns null if no schedule exists.
+   */
+  getNextBillingDate: (merchantId: string) => Date | null;
+
+  /**
+   * Advance a merchant's schedule to the next period (call after a successful charge).
+   */
+  advanceSchedule: (merchantId: string) => void;
+
+  /**
+   * Generate a draft invoice for a subscription billing period.
+   * Handles pro-rata calculation when joinDate is provided.
+   */
+  generateInvoice: (params: {
+    subscriptionId: string;
+    merchantId: string;
+    periodStart: Date;
+    periodEnd: Date;
+    billingDate: Date;
+    amount: number;
+    currency: string;
+    joinDate?: Date;
+  }) => CalendarInvoice;
+
+  /**
+   * Update an invoice's status.
+   */
+  updateInvoiceStatus: (invoiceId: string, status: CalendarInvoice['status']) => void;
+
+  /**
+   * Get all invoices for a subscription, sorted newest first.
+   */
+  getInvoicesForSubscription: (subscriptionId: string) => CalendarInvoice[];
+
+  /**
+   * Get all invoices for a merchant, sorted newest first.
+   */
+  getInvoicesForMerchant: (merchantId: string) => CalendarInvoice[];
+
+  /**
+   * Calculate a pro-rata amount for a mid-period subscription start.
+   */
+  calculateProRata: (
+    fullAmount: number,
+    periodStart: Date,
+    periodEnd: Date,
+    joinDate: Date
+  ) => number;
+
+  clearError: () => void;
+}
+
+// ── Store ──────────────────────────────────────────────────────────────────
+
+export const useBillingStore = create<BillingState>()(
+  persist(
+    (set, get) => ({
+      schedules: {},
+      invoices: {},
+      isLoading: false,
+      error: null,
+
+      setMerchantCalendarBilling: (merchantId, config) => {
+        try {
+          const schedule = setCalendarBilling(merchantId, config, new Date());
+          set((state) => ({
+            schedules: { ...state.schedules, [merchantId]: schedule },
+            error: null,
+          }));
+        } catch (err) {
+          set({ error: err instanceof Error ? err.message : 'Failed to set billing schedule.' });
+        }
+      },
+
+      removeMerchantCalendarBilling: (merchantId) => {
+        set((state) => {
+          const next = { ...state.schedules };
+          delete next[merchantId];
+          return { schedules: next };
+        });
+      },
+
+      getNextBillingDate: (merchantId) => {
+        const schedule = get().schedules[merchantId];
+        if (!schedule) return null;
+        return new Date(schedule.nextBillingDate);
+      },
+
+      advanceSchedule: (merchantId) => {
+        const schedule = get().schedules[merchantId];
+        if (!schedule) return;
+        const advanced = advanceMerchantBillingSchedule(schedule);
+        set((state) => ({
+          schedules: { ...state.schedules, [merchantId]: advanced },
+        }));
+      },
+
+      generateInvoice: ({ subscriptionId, merchantId, periodStart, periodEnd, billingDate, amount, currency, joinDate }) => {
+        const invoice = generateCalendarInvoice(
+          subscriptionId,
+          merchantId,
+          periodStart,
+          periodEnd,
+          billingDate,
+          amount,
+          currency,
+          joinDate
+        );
+        set((state) => ({
+          invoices: { ...state.invoices, [invoice.id]: invoice },
+        }));
+        return invoice;
+      },
+
+      updateInvoiceStatus: (invoiceId, status) => {
+        set((state) => {
+          const invoice = state.invoices[invoiceId];
+          if (!invoice) return state;
+          return {
+            invoices: {
+              ...state.invoices,
+              [invoiceId]: { ...invoice, status },
+            },
+          };
+        });
+      },
+
+      getInvoicesForSubscription: (subscriptionId) => {
+        return Object.values(get().invoices)
+          .filter((inv) => inv.subscriptionId === subscriptionId)
+          .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+      },
+
+      getInvoicesForMerchant: (merchantId) => {
+        return Object.values(get().invoices)
+          .filter((inv) => inv.merchantId === merchantId)
+          .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+      },
+
+      calculateProRata: (fullAmount, periodStart, periodEnd, joinDate) => {
+        return calculateProRataAmount(fullAmount, periodStart, periodEnd, joinDate);
+      },
+
+      clearError: () => set({ error: null }),
+    }),
+    {
+      name: STORAGE_KEY,
+      storage: createJSONStorage(() => AsyncStorage),
+      partialize: (state) => ({
+        schedules: state.schedules,
+        invoices: state.invoices,
+      }),
+    }
+  )
+);
+
+// ── Re-export types for convenience ───────────────────────────────────────
+export type { AdjustmentPolicy, CalendarBilling, CalendarInvoice, MerchantBillingSchedule };
+
+// ── Utility re-exports ────────────────────────────────────────────────────
+export { calculateNextBillingDate };

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -1,5 +1,58 @@
 export type CalendarProvider = 'google' | 'apple' | 'outlook';
 
+// ── Calendar Billing Types ─────────────────────────────────────────────────
+
+/**
+ * Policy for handling months that don't have the target day_of_month.
+ * - 'last_day': bill on the last day of the month (e.g. Jan 31 → Feb 28)
+ * - 'first_day_next': bill on the 1st of the following month
+ * - 'skip': skip billing for that month
+ */
+export type AdjustmentPolicy = 'last_day' | 'first_day_next' | 'skip';
+
+/**
+ * Calendar-based billing configuration for a merchant or subscription.
+ * Allows billing to be anchored to a specific calendar day rather than
+ * the subscription creation date.
+ */
+export interface CalendarBilling {
+  /** Day of month to bill on (1–31). Values > 28 are subject to adjustment_policy. */
+  day_of_month: number;
+  /** How many months between billing cycles (1 = monthly, 3 = quarterly, 12 = yearly). */
+  billing_months_interval: number;
+  /** How to handle months that don't have the target day. */
+  adjustment_policy: AdjustmentPolicy;
+  /** Optional timezone for interpreting the billing day. Defaults to 'UTC'. */
+  timezone?: string;
+}
+
+/** A generated invoice for a calendar-billing period. */
+export interface CalendarInvoice {
+  id: string;
+  subscriptionId: string;
+  merchantId: string;
+  periodStart: string; // ISO date string
+  periodEnd: string;   // ISO date string
+  billingDate: string; // ISO date string — the actual calendar-adjusted date
+  amount: number;
+  currency: string;
+  /** Pro-rata amount if the subscription started mid-period. */
+  proratedAmount?: number;
+  isProratedPeriod: boolean;
+  status: 'draft' | 'issued' | 'paid' | 'void';
+  createdAt: string;
+}
+
+/** Per-merchant calendar billing schedule. */
+export interface MerchantBillingSchedule {
+  merchantId: string;
+  config: CalendarBilling;
+  /** ISO date string of the next scheduled billing date. */
+  nextBillingDate: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface PendingCalendarAuthorization {
   provider: CalendarProvider;
   state: string;

--- a/src/utils/__tests__/calendarBilling.test.ts
+++ b/src/utils/__tests__/calendarBilling.test.ts
@@ -1,0 +1,411 @@
+/**
+ * Tests for calendar-based billing calculations (Issue #182).
+ *
+ * Covers:
+ * - daysInMonth (including leap years)
+ * - normalizeBillingDay (all three adjustment policies)
+ * - calculateNextBillingDate (monthly, quarterly, year-boundary)
+ * - calculateProRataAmount
+ * - generateCalendarInvoice
+ * - setCalendarBilling / advanceMerchantBillingSchedule
+ */
+
+import {
+  advanceMerchantBillingSchedule,
+  calculateNextBillingDate,
+  calculateProRataAmount,
+  daysInMonth,
+  generateCalendarInvoice,
+  normalizeBillingDay,
+  setCalendarBilling,
+} from '../../services/calendarService';
+import type { CalendarBilling } from '../../types/calendar';
+
+// ── daysInMonth ────────────────────────────────────────────────────────────
+
+describe('daysInMonth', () => {
+  it('returns 31 for January', () => {
+    expect(daysInMonth(2025, 1)).toBe(31);
+  });
+
+  it('returns 28 for February in a non-leap year', () => {
+    expect(daysInMonth(2025, 2)).toBe(28);
+  });
+
+  it('returns 29 for February in a leap year', () => {
+    expect(daysInMonth(2024, 2)).toBe(29);
+  });
+
+  it('returns 30 for April', () => {
+    expect(daysInMonth(2025, 4)).toBe(30);
+  });
+
+  it('returns 31 for December', () => {
+    expect(daysInMonth(2025, 12)).toBe(31);
+  });
+});
+
+// ── normalizeBillingDay ────────────────────────────────────────────────────
+
+describe('normalizeBillingDay', () => {
+  describe('day exists in month', () => {
+    it('returns the day unchanged when it fits', () => {
+      expect(normalizeBillingDay(15, 3, 2025, 'last_day')).toEqual({ year: 2025, month: 3, day: 15 });
+    });
+
+    it('returns day 28 in February non-leap year when target is 28', () => {
+      expect(normalizeBillingDay(28, 2, 2025, 'last_day')).toEqual({ year: 2025, month: 2, day: 28 });
+    });
+
+    it('returns day 29 in February leap year when target is 29', () => {
+      expect(normalizeBillingDay(29, 2, 2024, 'last_day')).toEqual({ year: 2024, month: 2, day: 29 });
+    });
+  });
+
+  describe('policy: last_day', () => {
+    it('Jan 31 → Feb: returns Feb 28 in non-leap year', () => {
+      expect(normalizeBillingDay(31, 2, 2025, 'last_day')).toEqual({ year: 2025, month: 2, day: 28 });
+    });
+
+    it('Jan 31 → Feb: returns Feb 29 in leap year', () => {
+      expect(normalizeBillingDay(31, 2, 2024, 'last_day')).toEqual({ year: 2024, month: 2, day: 29 });
+    });
+
+    it('31st → April: returns April 30', () => {
+      expect(normalizeBillingDay(31, 4, 2025, 'last_day')).toEqual({ year: 2025, month: 4, day: 30 });
+    });
+
+    it('30th → February: returns Feb 28', () => {
+      expect(normalizeBillingDay(30, 2, 2025, 'last_day')).toEqual({ year: 2025, month: 2, day: 28 });
+    });
+  });
+
+  describe('policy: first_day_next', () => {
+    it('Jan 31 → Feb: returns March 1', () => {
+      expect(normalizeBillingDay(31, 2, 2025, 'first_day_next')).toEqual({ year: 2025, month: 3, day: 1 });
+    });
+
+    it('31st → April: returns May 1', () => {
+      expect(normalizeBillingDay(31, 4, 2025, 'first_day_next')).toEqual({ year: 2025, month: 5, day: 1 });
+    });
+
+    it('rolls over year boundary: Dec 31 → Feb: returns March 1 next year', () => {
+      // February doesn't have 31 days; first_day_next → March 1
+      expect(normalizeBillingDay(31, 2, 2025, 'first_day_next')).toEqual({ year: 2025, month: 3, day: 1 });
+    });
+
+    it('handles December → January year rollover', () => {
+      // 31st in a 30-day month with first_day_next
+      expect(normalizeBillingDay(31, 11, 2025, 'first_day_next')).toEqual({ year: 2025, month: 12, day: 1 });
+    });
+  });
+
+  describe('policy: skip', () => {
+    it('returns null when day exceeds month length', () => {
+      expect(normalizeBillingDay(31, 2, 2025, 'skip')).toBeNull();
+    });
+
+    it('returns null for 30th in February', () => {
+      expect(normalizeBillingDay(30, 2, 2025, 'skip')).toBeNull();
+    });
+
+    it('returns the day when it fits (no skip needed)', () => {
+      expect(normalizeBillingDay(15, 2, 2025, 'skip')).toEqual({ year: 2025, month: 2, day: 15 });
+    });
+  });
+});
+
+// ── calculateNextBillingDate ───────────────────────────────────────────────
+
+describe('calculateNextBillingDate', () => {
+  const monthlyOn1st: CalendarBilling = {
+    day_of_month: 1,
+    billing_months_interval: 1,
+    adjustment_policy: 'last_day',
+    timezone: 'UTC',
+  };
+
+  it('returns the 1st of next month when current date is past the 1st', () => {
+    const current = new Date('2025-01-15T00:00:00Z');
+    const next = calculateNextBillingDate(current, monthlyOn1st);
+    expect(next.getUTCFullYear()).toBe(2025);
+    expect(next.getUTCMonth() + 1).toBe(2); // February
+    expect(next.getUTCDate()).toBe(1);
+  });
+
+  it('returns the 1st of the same month when current date is before the 1st', () => {
+    // Day 1 of January — we're on Jan 1, so we've already hit it; next is Feb 1
+    const current = new Date('2025-01-01T00:00:00Z');
+    const next = calculateNextBillingDate(current, monthlyOn1st);
+    expect(next.getUTCMonth() + 1).toBe(2);
+    expect(next.getUTCDate()).toBe(1);
+  });
+
+  it('handles month-end billing: 31st with last_day policy', () => {
+    const config: CalendarBilling = {
+      day_of_month: 31,
+      billing_months_interval: 1,
+      adjustment_policy: 'last_day',
+      timezone: 'UTC',
+    };
+    // From Jan 15, next billing is Jan 31
+    const current = new Date('2025-01-15T00:00:00Z');
+    const next = calculateNextBillingDate(current, config);
+    expect(next.getUTCMonth() + 1).toBe(1);
+    expect(next.getUTCDate()).toBe(31);
+  });
+
+  it('handles Feb 28/29 edge case with last_day policy', () => {
+    const config: CalendarBilling = {
+      day_of_month: 31,
+      billing_months_interval: 1,
+      adjustment_policy: 'last_day',
+      timezone: 'UTC',
+    };
+    // From Jan 31, next billing is Feb 28 (non-leap 2025)
+    const current = new Date('2025-01-31T00:00:00Z');
+    const next = calculateNextBillingDate(current, config);
+    expect(next.getUTCMonth() + 1).toBe(2);
+    expect(next.getUTCDate()).toBe(28);
+  });
+
+  it('handles Feb 29 in a leap year with last_day policy', () => {
+    const config: CalendarBilling = {
+      day_of_month: 31,
+      billing_months_interval: 1,
+      adjustment_policy: 'last_day',
+      timezone: 'UTC',
+    };
+    // From Jan 31 2024, next billing is Feb 29 (leap year)
+    const current = new Date('2024-01-31T00:00:00Z');
+    const next = calculateNextBillingDate(current, config);
+    expect(next.getUTCMonth() + 1).toBe(2);
+    expect(next.getUTCDate()).toBe(29);
+  });
+
+  it('handles quarterly billing crossing year boundary', () => {
+    const config: CalendarBilling = {
+      day_of_month: 15,
+      billing_months_interval: 3,
+      adjustment_policy: 'last_day',
+      timezone: 'UTC',
+    };
+    // From Nov 15, next quarterly billing is Feb 15
+    const current = new Date('2025-11-15T00:00:00Z');
+    const next = calculateNextBillingDate(current, config);
+    expect(next.getUTCFullYear()).toBe(2026);
+    expect(next.getUTCMonth() + 1).toBe(2);
+    expect(next.getUTCDate()).toBe(15);
+  });
+
+  it('skips months with skip policy and finds next valid month', () => {
+    const config: CalendarBilling = {
+      day_of_month: 31,
+      billing_months_interval: 1,
+      adjustment_policy: 'skip',
+      timezone: 'UTC',
+    };
+    // From Jan 31, February is skipped (no 31st), next is March 31
+    const current = new Date('2025-01-31T00:00:00Z');
+    const next = calculateNextBillingDate(current, config);
+    expect(next.getUTCMonth() + 1).toBe(3); // March
+    expect(next.getUTCDate()).toBe(31);
+  });
+
+  it('handles first_day_next policy for month-end billing', () => {
+    const config: CalendarBilling = {
+      day_of_month: 31,
+      billing_months_interval: 1,
+      adjustment_policy: 'first_day_next',
+      timezone: 'UTC',
+    };
+    // From Jan 31, Feb doesn't have 31st → March 1
+    const current = new Date('2025-01-31T00:00:00Z');
+    const next = calculateNextBillingDate(current, config);
+    expect(next.getUTCMonth() + 1).toBe(3); // March
+    expect(next.getUTCDate()).toBe(1);
+  });
+
+  it('handles annual billing', () => {
+    const config: CalendarBilling = {
+      day_of_month: 1,
+      billing_months_interval: 12,
+      adjustment_policy: 'last_day',
+      timezone: 'UTC',
+    };
+    const current = new Date('2025-03-01T00:00:00Z');
+    const next = calculateNextBillingDate(current, config);
+    expect(next.getUTCFullYear()).toBe(2026);
+    expect(next.getUTCMonth() + 1).toBe(3);
+    expect(next.getUTCDate()).toBe(1);
+  });
+});
+
+// ── calculateProRataAmount ─────────────────────────────────────────────────
+
+describe('calculateProRataAmount', () => {
+  it('returns full amount when join date is at period start', () => {
+    const start = new Date('2025-01-01T00:00:00Z');
+    const end = new Date('2025-02-01T00:00:00Z');
+    expect(calculateProRataAmount(100, start, end, start)).toBe(100);
+  });
+
+  it('returns 0 when join date is at period end', () => {
+    const start = new Date('2025-01-01T00:00:00Z');
+    const end = new Date('2025-02-01T00:00:00Z');
+    expect(calculateProRataAmount(100, start, end, end)).toBe(0);
+  });
+
+  it('returns approximately half for mid-period join', () => {
+    const start = new Date('2025-01-01T00:00:00Z');
+    const end = new Date('2025-01-31T00:00:00Z');
+    const mid = new Date('2025-01-16T00:00:00Z'); // ~halfway
+    const result = calculateProRataAmount(100, start, end, mid);
+    expect(result).toBeGreaterThan(40);
+    expect(result).toBeLessThan(60);
+  });
+
+  it('returns full amount when join date is before period start', () => {
+    const start = new Date('2025-01-15T00:00:00Z');
+    const end = new Date('2025-02-15T00:00:00Z');
+    const joinBefore = new Date('2025-01-01T00:00:00Z');
+    expect(calculateProRataAmount(100, start, end, joinBefore)).toBe(100);
+  });
+
+  it('rounds to 2 decimal places', () => {
+    const start = new Date('2025-01-01T00:00:00Z');
+    const end = new Date('2025-01-31T00:00:00Z');
+    const join = new Date('2025-01-10T00:00:00Z');
+    const result = calculateProRataAmount(99.99, start, end, join);
+    expect(result.toString()).toMatch(/^\d+\.\d{1,2}$/);
+  });
+
+  it('handles zero-length period gracefully', () => {
+    const date = new Date('2025-01-01T00:00:00Z');
+    expect(calculateProRataAmount(100, date, date, date)).toBe(100);
+  });
+});
+
+// ── generateCalendarInvoice ────────────────────────────────────────────────
+
+describe('generateCalendarInvoice', () => {
+  const periodStart = new Date('2025-01-01T00:00:00Z');
+  const periodEnd = new Date('2025-02-01T00:00:00Z');
+  const billingDate = new Date('2025-02-01T00:00:00Z');
+
+  it('generates a draft invoice with correct fields', () => {
+    const invoice = generateCalendarInvoice(
+      'sub_1',
+      'merchant_1',
+      periodStart,
+      periodEnd,
+      billingDate,
+      99.99,
+      'USD'
+    );
+
+    expect(invoice.subscriptionId).toBe('sub_1');
+    expect(invoice.merchantId).toBe('merchant_1');
+    expect(invoice.amount).toBe(99.99);
+    expect(invoice.currency).toBe('USD');
+    expect(invoice.status).toBe('draft');
+    expect(invoice.isProratedPeriod).toBe(false);
+    expect(invoice.proratedAmount).toBeUndefined();
+    expect(invoice.id).toMatch(/^inv_/);
+  });
+
+  it('sets isProratedPeriod and calculates proratedAmount when joinDate is provided', () => {
+    const joinDate = new Date('2025-01-15T00:00:00Z');
+    const invoice = generateCalendarInvoice(
+      'sub_1',
+      'merchant_1',
+      periodStart,
+      periodEnd,
+      billingDate,
+      100,
+      'USD',
+      joinDate
+    );
+
+    expect(invoice.isProratedPeriod).toBe(true);
+    expect(invoice.proratedAmount).toBeDefined();
+    expect(invoice.proratedAmount!).toBeLessThan(100);
+    expect(invoice.proratedAmount!).toBeGreaterThan(0);
+  });
+
+  it('does not set isProratedPeriod when joinDate equals periodStart', () => {
+    const invoice = generateCalendarInvoice(
+      'sub_1',
+      'merchant_1',
+      periodStart,
+      periodEnd,
+      billingDate,
+      100,
+      'USD',
+      periodStart
+    );
+    // joinDate === periodStart means not mid-period
+    expect(invoice.isProratedPeriod).toBe(false);
+  });
+
+  it('generates unique IDs for each invoice', () => {
+    const inv1 = generateCalendarInvoice('sub_1', 'merchant_1', periodStart, periodEnd, billingDate, 100, 'USD');
+    const inv2 = generateCalendarInvoice('sub_1', 'merchant_1', periodStart, periodEnd, billingDate, 100, 'USD');
+    expect(inv1.id).not.toBe(inv2.id);
+  });
+});
+
+// ── setCalendarBilling / advanceMerchantBillingSchedule ───────────────────
+
+describe('setCalendarBilling', () => {
+  it('creates a schedule with the correct config and a future nextBillingDate', () => {
+    const config: CalendarBilling = {
+      day_of_month: 15,
+      billing_months_interval: 1,
+      adjustment_policy: 'last_day',
+      timezone: 'UTC',
+    };
+    const schedule = setCalendarBilling('merchant_1', config, new Date('2025-01-10T00:00:00Z'));
+
+    expect(schedule.merchantId).toBe('merchant_1');
+    expect(schedule.config).toEqual(config);
+    const nextDate = new Date(schedule.nextBillingDate);
+    expect(nextDate.getUTCDate()).toBe(15);
+    expect(nextDate.getUTCMonth() + 1).toBe(1); // January 15
+  });
+});
+
+describe('advanceMerchantBillingSchedule', () => {
+  it('advances the schedule to the next billing period', () => {
+    const config: CalendarBilling = {
+      day_of_month: 1,
+      billing_months_interval: 1,
+      adjustment_policy: 'last_day',
+      timezone: 'UTC',
+    };
+    const schedule = setCalendarBilling('merchant_1', config, new Date('2025-01-15T00:00:00Z'));
+    // nextBillingDate should be Feb 1
+    expect(new Date(schedule.nextBillingDate).getUTCMonth() + 1).toBe(2);
+
+    const advanced = advanceMerchantBillingSchedule(schedule);
+    // After advancing from Feb 1, next should be March 1
+    expect(new Date(advanced.nextBillingDate).getUTCMonth() + 1).toBe(3);
+    expect(new Date(advanced.nextBillingDate).getUTCDate()).toBe(1);
+  });
+
+  it('handles quarterly advancement across year boundary', () => {
+    const config: CalendarBilling = {
+      day_of_month: 15,
+      billing_months_interval: 3,
+      adjustment_policy: 'last_day',
+      timezone: 'UTC',
+    };
+    const schedule = setCalendarBilling('merchant_1', config, new Date('2025-11-15T00:00:00Z'));
+    // nextBillingDate should be Feb 15 2026
+    const advanced = advanceMerchantBillingSchedule(schedule);
+    const nextDate = new Date(advanced.nextBillingDate);
+    expect(nextDate.getUTCFullYear()).toBe(2026);
+    expect(nextDate.getUTCMonth() + 1).toBe(5); // May
+    expect(nextDate.getUTCDate()).toBe(15);
+  });
+});


### PR DESCRIPTION
Implements calendar-based billing so merchants can bill on specific calendar dates instead of subscription creation date.

Changes

Added CalendarBilling, CalendarInvoice, MerchantBillingSchedule types
Added scheduling logic: normalizeBillingDay, calculateNextBillingDate, calculateProRataAmount, generateCalendarInvoice
New billingStore (Zustand, persisted) for per-merchant schedules and invoices
New BillingSettingsScreen with day picker, interval selector, short-month policy config, live edge case preview, invoice list, and pro-rata calculator
30+ unit tests covering all edge cases
Edge cases handled: Jan 31 → Feb 28/29, leap year Feb 29, quarterly year-boundary, timezone-aware scheduling, mid-period pro-rata.

Closes #182
