### PR TITLE
feat: implement subscription deletion with confirmation dialog

### DIFF
--- a/src/components/home/SubscriptionList.tsx
+++ b/src/components/home/SubscriptionList.tsx
@@ -16,6 +16,7 @@ interface SubscriptionListProps {
   totalCount: number;
   onSubscriptionPress: (sub: Subscription) => void;
   onToggleStatus: (id: string) => void;
+  onDelete: (id: string) => void;
   onAddFirstPress: () => void;
 }
 
@@ -30,6 +31,7 @@ export const SubscriptionList: React.FC<SubscriptionListProps> = React.memo(
     totalCount,
     onSubscriptionPress,
     onToggleStatus,
+    onDelete,
     onAddFirstPress,
   }) => {
     usePerformanceProfiler('SubscriptionList', {
@@ -43,9 +45,10 @@ export const SubscriptionList: React.FC<SubscriptionListProps> = React.memo(
           subscription={item}
           onPress={onSubscriptionPress}
           onToggleStatus={onToggleStatus}
+          onDelete={onDelete}
         />
       ),
-      [onSubscriptionPress, onToggleStatus]
+      [onSubscriptionPress, onToggleStatus, onDelete]
     );
 
     const keyExtractor = useCallback((item: Subscription) => item.id, []);

--- a/src/components/subscription/SubscriptionCard.tsx
+++ b/src/components/subscription/SubscriptionCard.tsx
@@ -22,10 +22,11 @@ export interface SubscriptionCardProps {
   subscription: Subscription;
   onPress: (subscription: Subscription) => void;
   onToggleStatus?: (id: string) => void;
+  onDelete?: (id: string) => void;
 }
 
 export const SubscriptionCard: React.FC<SubscriptionCardProps> = React.memo(
-  ({ subscription, onPress, onToggleStatus }) => {
+  ({ subscription, onPress, onToggleStatus, onDelete }) => {
     const handleToggleStatus = () => {
       if (onToggleStatus) {
         Alert.alert(
@@ -34,6 +35,22 @@ export const SubscriptionCard: React.FC<SubscriptionCardProps> = React.memo(
           [
             { text: 'Cancel', style: 'cancel' },
             { text: 'Confirm', onPress: () => onToggleStatus(subscription.id) },
+          ]
+        );
+      }
+    };
+
+    const handleDelete = () => {
+      if (onDelete) {
+        const cryptoWarning = subscription.isCryptoEnabled
+          ? '\n\nThis subscription has an active crypto stream. On-chain cancellation cannot be undone.'
+          : '';
+        Alert.alert(
+          'Delete Subscription',
+          `Remove "${subscription.name}" from your subscriptions?${cryptoWarning}`,
+          [
+            { text: 'Cancel', style: 'cancel' },
+            { text: 'Delete', style: 'destructive', onPress: () => onDelete(subscription.id) },
           ]
         );
       }
@@ -144,19 +161,32 @@ export const SubscriptionCard: React.FC<SubscriptionCardProps> = React.memo(
           </Text>
         )}
 
-        {onToggleStatus && (
-          <TouchableOpacity
-            style={styles.toggleButton}
-            onPress={handleToggleStatus}
-            activeOpacity={0.7}
-            testID={`subscription-toggle-${subscription.id}`}
-            accessibilityRole="button"
-            accessibilityLabel={
-              subscription.isActive ? `Pause ${subscription.name}` : `Activate ${subscription.name}`
-            }>
-            <Text style={styles.toggleText}>{subscription.isActive ? 'Pause' : 'Activate'}</Text>
-          </TouchableOpacity>
-        )}
+        <View style={styles.actionsRow}>
+          {onToggleStatus && (
+            <TouchableOpacity
+              style={styles.toggleButton}
+              onPress={handleToggleStatus}
+              activeOpacity={0.7}
+              testID={`subscription-toggle-${subscription.id}`}
+              accessibilityRole="button"
+              accessibilityLabel={
+                subscription.isActive ? `Pause ${subscription.name}` : `Activate ${subscription.name}`
+              }>
+              <Text style={styles.toggleText}>{subscription.isActive ? 'Pause' : 'Activate'}</Text>
+            </TouchableOpacity>
+          )}
+          {onDelete && (
+            <TouchableOpacity
+              style={styles.deleteButton}
+              onPress={handleDelete}
+              activeOpacity={0.7}
+              testID={`subscription-delete-${subscription.id}`}
+              accessibilityRole="button"
+              accessibilityLabel={`Delete ${subscription.name}`}>
+              <Text style={styles.deleteText}>Delete</Text>
+            </TouchableOpacity>
+          )}
+        </View>
       </TouchableOpacity>
     );
   }
@@ -290,6 +320,24 @@ const styles = StyleSheet.create({
   toggleText: {
     ...typography.caption,
     color: colors.text,
+    fontWeight: '500',
+  },
+  actionsRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: spacing.sm,
+  },
+  deleteButton: {
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    backgroundColor: colors.surface,
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    borderColor: colors.error,
+  },
+  deleteText: {
+    ...typography.caption,
+    color: colors.error,
     fontWeight: '500',
   },
 });

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -33,7 +33,7 @@ type HomeNavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
 const HomeScreen: React.FC = () => {
   const navigation = useNavigation<HomeNavigationProp>();
-  const { subscriptions, stats, fetchSubscriptions, calculateStats, toggleSubscriptionStatus } =
+  const { subscriptions, stats, fetchSubscriptions, calculateStats, toggleSubscriptionStatus, deleteSubscription } =
     useSubscriptionStore();
 
   const isOnline = useTransactionQueueStore((state) => state.isOnline);
@@ -73,6 +73,10 @@ const HomeScreen: React.FC = () => {
 
   const handleToggleStatus = async (id: string) => {
     await toggleSubscriptionStatus(id);
+  };
+
+  const handleDelete = async (id: string) => {
+    await deleteSubscription(id);
   };
 
   return (
@@ -169,6 +173,7 @@ const HomeScreen: React.FC = () => {
           totalCount={subscriptions.length}
           onSubscriptionPress={(sub) => navigation.navigate('SubscriptionDetail', { id: sub.id })}
           onToggleStatus={handleToggleStatus}
+          onDelete={handleDelete}
           onAddFirstPress={() => navigation.navigate('AddSubscription')}
         />
       </ScrollView>


### PR DESCRIPTION
 Summary
  
  Implements delete functionality for subscriptions with a confirmation dialog before removal.
  
  Changes
  
  - SubscriptionCard — added onDelete prop; shows an Alert confirmation with a destructive "Delete" button. Includes a crypto stream warning when isCryptoEnabled is true, noting on-chain
  cancellation cannot be undone.
  - SubscriptionList — added onDelete to props interface and wired it through to SubscriptionCard.
  - HomeScreen — connects deleteSubscription from the store via a handleDelete callback passed to SubscriptionList.
  
  No store changes needed — deleteSubscription already existed and handles state removal, stats recalculation, renewal reminder sync, and calendar cleanup.
  
  Acceptance Criteria
  
  - [x] Delete button visible on each subscription card
  - [x] Confirmation dialog shown before deletion
  - [x] Subscription removed from store on confirm
  - [x] Persisted storage updated (via existing store logic)
  - [x] Crypto stream warning shown when isCryptoEnabled is true
  
  Closes #45