### PR TITLE
fix: improve date initialization in AddSubscriptionScreen and add val…

### DIFF
--- a/src/screens/AddSubscriptionScreen.tsx
+++ b/src/screens/AddSubscriptionScreen.tsx
@@ -18,6 +18,7 @@ import { useSubscriptionStore, useSettingsStore } from '../store';
 import { Button } from '../components/common/Button';
 import { getCurrencySymbol } from '../utils/formatting';
 import { colors, spacing, typography, borderRadius } from '../utils/constants';
+import { advanceBillingDate } from '../utils/billingDate';
 
 import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import { errorHandler } from '../services/errorHandler';
@@ -27,6 +28,8 @@ import { BillingCycle, SubscriptionCategory } from '../types/subscription';
 interface AddSubscriptionFormData extends SubscriptionFormData {
   priceError: string;
 }
+
+const getDefaultNextBillingDate = (cycle: BillingCycle) => advanceBillingDate(new Date(), cycle);
 
 const AddSubscriptionScreen: React.FC = () => {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
@@ -41,7 +44,7 @@ const AddSubscriptionScreen: React.FC = () => {
     priceError: '',
     currency: preferredCurrency,
     billingCycle: BillingCycle.MONTHLY,
-    nextBillingDate: new Date(),
+    nextBillingDate: getDefaultNextBillingDate(BillingCycle.MONTHLY),
     notificationsEnabled: true,
     isCryptoEnabled: false,
     cryptoToken: undefined,
@@ -73,7 +76,11 @@ const AddSubscriptionScreen: React.FC = () => {
 
   const handleBillingCycleSelect = (cycle: BillingCycle) => {
     setSelectedBillingCycle(cycle);
-    setFormData((prev) => ({ ...prev, billingCycle: cycle }));
+    setFormData((prev) => ({
+      ...prev,
+      billingCycle: cycle,
+      nextBillingDate: getDefaultNextBillingDate(cycle),
+    }));
   };
 
   const handleInputChange = (
@@ -131,6 +138,16 @@ const AddSubscriptionScreen: React.FC = () => {
       const validationError = new Error(
         formData.priceError || 'Invalid price: must be greater than 0'
       );
+      const appError = errorHandler.handleError(validationError, {
+        action: 'validateSubscription',
+        component: 'AddSubscriptionScreen',
+      });
+      Alert.alert('Validation Error', appError.userMessage);
+      return;
+    }
+
+    if (formData.nextBillingDate.getTime() < Date.now()) {
+      const validationError = new Error('Next billing date cannot be in the past');
       const appError = errorHandler.handleError(validationError, {
         action: 'validateSubscription',
         component: 'AddSubscriptionScreen',

--- a/src/utils/__tests__/billingDate.test.ts
+++ b/src/utils/__tests__/billingDate.test.ts
@@ -1,0 +1,34 @@
+import { advanceBillingDate } from '../billingDate';
+import { BillingCycle } from '../../types/subscription';
+
+describe('advanceBillingDate', () => {
+  it('adds 7 days for weekly cycles', () => {
+    const start = new Date(2026, 4, 1, 10, 0, 0); // May 1, 2026
+    const next = advanceBillingDate(start, BillingCycle.WEEKLY);
+    expect(next).toEqual(new Date(2026, 4, 8, 10, 0, 0));
+  });
+
+  it('advances one month and preserves time for monthly cycles', () => {
+    const start = new Date(2026, 4, 1, 10, 0, 0);
+    const next = advanceBillingDate(start, BillingCycle.MONTHLY);
+    expect(next).toEqual(new Date(2026, 5, 1, 10, 0, 0));
+  });
+
+  it('rolls last-of-month to month end for monthly cycles', () => {
+    const start = new Date(2026, 0, 31, 10, 0, 0); // Jan 31, 2026
+    const next = advanceBillingDate(start, BillingCycle.MONTHLY);
+    expect(next).toEqual(new Date(2026, 1, 28, 10, 0, 0));
+  });
+
+  it('rolls leap-day to February 28 on a non-leap year for yearly cycles', () => {
+    const start = new Date(2024, 1, 29, 10, 0, 0); // Feb 29, 2024
+    const next = advanceBillingDate(start, BillingCycle.YEARLY);
+    expect(next).toEqual(new Date(2025, 1, 28, 10, 0, 0));
+  });
+
+  it('uses monthly fallback for custom billing cycles', () => {
+    const start = new Date(2026, 2, 31, 10, 0, 0); // Mar 31, 2026
+    const next = advanceBillingDate(start, BillingCycle.CUSTOM);
+    expect(next).toEqual(new Date(2026, 3, 30, 10, 0, 0));
+  });
+});

--- a/src/utils/billingDate.ts
+++ b/src/utils/billingDate.ts
@@ -1,5 +1,40 @@
 import { BillingCycle } from '../types/subscription';
 
+function addMonths(date: Date, months: number): Date {
+  const result = new Date(date.getTime());
+  const day = result.getDate();
+  result.setDate(1);
+  result.setMonth(result.getMonth() + months);
+
+  const daysInTargetMonth = new Date(
+    result.getFullYear(),
+    result.getMonth() + 1,
+    0
+  ).getDate();
+  result.setDate(Math.min(day, daysInTargetMonth));
+
+  return result;
+}
+
+function addYears(date: Date, years: number): Date {
+  const result = new Date(date.getTime());
+  const month = result.getMonth();
+  const day = result.getDate();
+
+  result.setDate(1);
+  result.setFullYear(result.getFullYear() + years);
+  result.setMonth(month);
+
+  const daysInTargetMonth = new Date(
+    result.getFullYear(),
+    month + 1,
+    0
+  ).getDate();
+  result.setDate(Math.min(day, daysInTargetMonth));
+
+  return result;
+}
+
 /** Advance `from` by one billing period (used after a successful renewal). */
 export function advanceBillingDate(from: Date, cycle: BillingCycle): Date {
   const d = new Date(from.getTime());
@@ -8,15 +43,12 @@ export function advanceBillingDate(from: Date, cycle: BillingCycle): Date {
       d.setDate(d.getDate() + 7);
       break;
     case BillingCycle.MONTHLY:
-      d.setMonth(d.getMonth() + 1);
-      break;
+      return addMonths(d, 1);
     case BillingCycle.YEARLY:
-      d.setFullYear(d.getFullYear() + 1);
-      break;
+      return addYears(d, 1);
     case BillingCycle.CUSTOM:
     default:
-      d.setMonth(d.getMonth() + 1);
-      break;
+      return addMonths(d, 1);
   }
   return d;
 }


### PR DESCRIPTION
Closes #43 

## Update Completed

- Fixed default `nextBillingDate` in AddSubscriptionScreen.tsx
  - Uses billing cycle to compute initial value instead of `new Date()`
  - Billing cycle selection now recalculates next billing date
  - Added submit validation to reject past billing dates
  - Kept UI picker behavior and minimum date restriction intact

- Improved billing date calculations in billingDate.ts
  - Weekly: adds 7 days
  - Monthly: advances one month while preserving end-of-month semantics
  - Yearly: advances one year with leap-year handling
  - Custom: falls back to monthly behavior

- Added coverage in billingDate.test.ts
  - weekly advance
  - monthly advance
  - month-end rollover
  - leap-year to non-leap-year rollover
  - custom fallback behavior

## Validation

- `get_errors` reports no issues in:
  - AddSubscriptionScreen.tsx
  - billingDate.ts
  - billingDate.test.ts

If you want, I can also add a UI-level test for `AddSubscriptionScreen` behavior.

Made changes.