### PR TITLE
refactor: extract shared stats calculation to src/utils/stats.ts

### DIFF
--- a/src/store/subscriptionStore.ts
+++ b/src/store/subscriptionStore.ts
@@ -9,9 +9,10 @@ import {
   BillingCycle, // eslint-disable-line
 } from '../types/subscription';
 import { dummySubscriptions } from '../utils/dummyData'; // eslint-disable-line
+import { calculateSubscriptionStats } from '../utils/stats';
 import { advanceBillingDate } from '../utils/billingDate';
 import { buildBillingPeriod } from '../utils/invoice';
-import { BILLING_CONVERSIONS, CACHE_CONSTANTS } from '../utils/constants/values';
+import { CACHE_CONSTANTS } from '../utils/constants/values';
 import {
   syncRenewalReminders,
   presentChargeSuccessNotification,
@@ -499,7 +500,6 @@ export const useSubscriptionStore = create<SubscriptionState>()(
       calculateStats: () => {
         const { subscriptions } = get();
 
-        // Safety check: ensure subscriptions is an array
         if (!subscriptions || !Array.isArray(subscriptions)) {
           set({
             stats: {
@@ -512,63 +512,15 @@ export const useSubscriptionStore = create<SubscriptionState>()(
           return;
         }
 
-        const activeSubs = subscriptions.filter((sub) => sub.isActive);
-
         const { preferredCurrency, exchangeRates } = useSettingsStore.getState();
         const rates = exchangeRates?.rates || {};
 
-        const totalMonthlySpend = activeSubs.reduce((total, sub) => {
-          const priceInPreferred = currencyService.convert(
-            sub.price,
-            sub.currency,
-            preferredCurrency,
-            rates
-          );
-          if (sub.billingCycle === 'monthly') return total + priceInPreferred;
-          if (sub.billingCycle === 'yearly') return total + priceInPreferred / 12;
-          if (sub.billingCycle === 'weekly')
-            return total + priceInPreferred * BILLING_CONVERSIONS.WEEKS_PER_MONTH;
-          return total + priceInPreferred;
-        }, 0);
-
-        const totalYearlySpend = activeSubs.reduce((total, sub) => {
-          const priceInPreferred = currencyService.convert(
-            sub.price,
-            sub.currency,
-            preferredCurrency,
-            rates
-          );
-          if (sub.billingCycle === 'yearly') return total + priceInPreferred;
-          if (sub.billingCycle === 'monthly')
-            return total + priceInPreferred * BILLING_CONVERSIONS.MONTHS_PER_YEAR;
-          if (sub.billingCycle === 'weekly')
-            return total + priceInPreferred * BILLING_CONVERSIONS.WEEKS_PER_YEAR;
-          return total + priceInPreferred * BILLING_CONVERSIONS.MONTHS_PER_YEAR;
-        }, 0);
-
-
-        const categoryBreakdown = activeSubs.reduce(
-          (acc, sub) => {
-            acc[sub.category] = (acc[sub.category] || 0) + 1;
-            return acc;
-          },
-          {} as Record<string, number>
+        const stats = calculateSubscriptionStats(
+          subscriptions,
+          (price, currency) => currencyService.convert(price, currency, preferredCurrency, rates)
         );
 
-        const totalGasSpent = activeSubs.reduce(
-          (total, sub) => total + (sub.totalGasSpent || 0),
-          0
-        );
-
-        set({
-          stats: {
-            totalActive: activeSubs.length,
-            totalMonthlySpend,
-            totalYearlySpend,
-            categoryBreakdown,
-            totalGasSpent,
-          },
-        });
+        set({ stats });
       },
     }),
     {

--- a/src/utils/__tests__/stats.test.ts
+++ b/src/utils/__tests__/stats.test.ts
@@ -1,0 +1,136 @@
+import { calculateSubscriptionStats, toMonthlyPrice, toYearlyPrice } from '../stats';
+import { Subscription, SubscriptionCategory, BillingCycle } from '../../types/subscription';
+import { BILLING_CONVERSIONS } from '../constants/values';
+
+const makeSubscription = (overrides: Partial<Subscription>): Subscription => ({
+  id: '1',
+  name: 'Test',
+  category: SubscriptionCategory.SOFTWARE,
+  price: 10,
+  currency: 'USD',
+  billingCycle: BillingCycle.MONTHLY,
+  nextBillingDate: new Date(),
+  isActive: true,
+  isCryptoEnabled: false,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});
+
+describe('toMonthlyPrice', () => {
+  it('returns price as-is for monthly', () => {
+    expect(toMonthlyPrice(12, BillingCycle.MONTHLY)).toBe(12);
+  });
+
+  it('divides by 12 for yearly', () => {
+    expect(toMonthlyPrice(120, BillingCycle.YEARLY)).toBe(10);
+  });
+
+  it('multiplies by weeks-per-month for weekly', () => {
+    expect(toMonthlyPrice(10, BillingCycle.WEEKLY)).toBeCloseTo(10 * BILLING_CONVERSIONS.WEEKS_PER_MONTH);
+  });
+
+  it('returns price as-is for custom', () => {
+    expect(toMonthlyPrice(10, BillingCycle.CUSTOM)).toBe(10);
+  });
+});
+
+describe('toYearlyPrice', () => {
+  it('returns price as-is for yearly', () => {
+    expect(toYearlyPrice(120, BillingCycle.YEARLY)).toBe(120);
+  });
+
+  it('multiplies by 12 for monthly', () => {
+    expect(toYearlyPrice(10, BillingCycle.MONTHLY)).toBe(120);
+  });
+
+  it('multiplies by 52 for weekly', () => {
+    expect(toYearlyPrice(10, BillingCycle.WEEKLY)).toBe(10 * BILLING_CONVERSIONS.WEEKS_PER_YEAR);
+  });
+
+  it('multiplies by 12 for custom', () => {
+    expect(toYearlyPrice(10, BillingCycle.CUSTOM)).toBe(120);
+  });
+});
+
+describe('calculateSubscriptionStats', () => {
+  it('returns zeros for empty array', () => {
+    const stats = calculateSubscriptionStats([]);
+    expect(stats.totalActive).toBe(0);
+    expect(stats.totalMonthlySpend).toBe(0);
+    expect(stats.totalYearlySpend).toBe(0);
+    expect(stats.categoryBreakdown).toEqual({});
+  });
+
+  it('returns zeros for null/undefined input', () => {
+    // @ts-expect-error testing invalid input
+    expect(calculateSubscriptionStats(null).totalActive).toBe(0);
+    // @ts-expect-error testing invalid input
+    expect(calculateSubscriptionStats(undefined).totalActive).toBe(0);
+  });
+
+  it('excludes inactive subscriptions', () => {
+    const subs = [
+      makeSubscription({ id: '1', isActive: true, price: 10 }),
+      makeSubscription({ id: '2', isActive: false, price: 20 }),
+    ];
+    const stats = calculateSubscriptionStats(subs);
+    expect(stats.totalActive).toBe(1);
+    expect(stats.totalMonthlySpend).toBe(10);
+  });
+
+  it('calculates monthly spend correctly for mixed billing cycles', () => {
+    const subs = [
+      makeSubscription({ id: '1', price: 10, billingCycle: BillingCycle.MONTHLY }),
+      makeSubscription({ id: '2', price: 120, billingCycle: BillingCycle.YEARLY }),
+    ];
+    const stats = calculateSubscriptionStats(subs);
+    // 10 + 120/12 = 10 + 10 = 20
+    expect(stats.totalMonthlySpend).toBeCloseTo(20);
+  });
+
+  it('calculates yearly spend correctly for mixed billing cycles', () => {
+    const subs = [
+      makeSubscription({ id: '1', price: 10, billingCycle: BillingCycle.MONTHLY }),
+      makeSubscription({ id: '2', price: 120, billingCycle: BillingCycle.YEARLY }),
+    ];
+    const stats = calculateSubscriptionStats(subs);
+    // 10*12 + 120 = 120 + 120 = 240
+    expect(stats.totalYearlySpend).toBeCloseTo(240);
+  });
+
+  it('applies price converter when provided', () => {
+    const subs = [makeSubscription({ price: 10, currency: 'EUR' })];
+    // Simulate 2x conversion rate
+    const stats = calculateSubscriptionStats(subs, (price) => price * 2);
+    expect(stats.totalMonthlySpend).toBe(20);
+    expect(stats.totalYearlySpend).toBe(240);
+  });
+
+  it('builds category breakdown correctly', () => {
+    const subs = [
+      makeSubscription({ id: '1', category: SubscriptionCategory.STREAMING }),
+      makeSubscription({ id: '2', category: SubscriptionCategory.STREAMING }),
+      makeSubscription({ id: '3', category: SubscriptionCategory.SOFTWARE }),
+    ];
+    const stats = calculateSubscriptionStats(subs);
+    expect(stats.categoryBreakdown[SubscriptionCategory.STREAMING]).toBe(2);
+    expect(stats.categoryBreakdown[SubscriptionCategory.SOFTWARE]).toBe(1);
+  });
+
+  it('sums totalGasSpent from active subscriptions', () => {
+    const subs = [
+      makeSubscription({ id: '1', totalGasSpent: 0.01 }),
+      makeSubscription({ id: '2', totalGasSpent: 0.02 }),
+      makeSubscription({ id: '3', isActive: false, totalGasSpent: 0.99 }),
+    ];
+    const stats = calculateSubscriptionStats(subs);
+    expect(stats.totalGasSpent).toBeCloseTo(0.03);
+  });
+
+  it('handles subscriptions with no totalGasSpent field', () => {
+    const subs = [makeSubscription({ id: '1' })];
+    const stats = calculateSubscriptionStats(subs);
+    expect(stats.totalGasSpent).toBe(0);
+  });
+});

--- a/src/utils/dummyData.ts
+++ b/src/utils/dummyData.ts
@@ -1,5 +1,6 @@
 import { Subscription, SubscriptionCategory, BillingCycle } from '../types/subscription';
-import { TIME_CONSTANTS, BILLING_CONVERSIONS, CACHE_CONSTANTS } from './constants/values';
+import { TIME_CONSTANTS, CACHE_CONSTANTS } from './constants/values';
+import { toMonthlyPrice } from './stats';
 
 export const dummySubscriptions: Subscription[] = [
   {
@@ -212,24 +213,5 @@ export const getTotalMonthlySpending = (subscriptions: Subscription[]): number =
 
   return subscriptions
     .filter((sub) => sub.isActive)
-    .reduce((total, sub) => {
-      let monthlyAmount = sub.price;
-
-      switch (sub.billingCycle) {
-        case BillingCycle.YEARLY:
-          monthlyAmount = sub.price / 12;
-          break;
-        case BillingCycle.WEEKLY:
-          monthlyAmount = sub.price * BILLING_CONVERSIONS.WEEKS_PER_MONTH; // Average weeks per month
-          break;
-        case BillingCycle.CUSTOM:
-          // For custom cycles, assume monthly for now
-          monthlyAmount = sub.price;
-          break;
-        default:
-          monthlyAmount = sub.price;
-      }
-
-      return total + monthlyAmount;
-    }, 0);
+    .reduce((total, sub) => total + toMonthlyPrice(sub.price, sub.billingCycle), 0);
 };

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -1,0 +1,96 @@
+import { Subscription, SubscriptionCategory, SubscriptionStats, BillingCycle } from '../types/subscription';
+import { BILLING_CONVERSIONS } from './constants/values';
+
+/**
+ * Optional price converter for currency-aware calculations.
+ * When omitted, raw subscription prices are used as-is.
+ */
+export type PriceConverter = (price: number, currency: string) => number;
+
+/**
+ * Converts a subscription's price to a monthly equivalent.
+ */
+export const toMonthlyPrice = (price: number, billingCycle: BillingCycle): number => {
+  switch (billingCycle) {
+    case BillingCycle.YEARLY:
+      return price / BILLING_CONVERSIONS.MONTHS_PER_YEAR;
+    case BillingCycle.WEEKLY:
+      return price * BILLING_CONVERSIONS.WEEKS_PER_MONTH;
+    case BillingCycle.MONTHLY:
+    case BillingCycle.CUSTOM:
+    default:
+      return price;
+  }
+};
+
+/**
+ * Converts a subscription's price to a yearly equivalent.
+ */
+export const toYearlyPrice = (price: number, billingCycle: BillingCycle): number => {
+  switch (billingCycle) {
+    case BillingCycle.YEARLY:
+      return price;
+    case BillingCycle.WEEKLY:
+      return price * BILLING_CONVERSIONS.WEEKS_PER_YEAR;
+    case BillingCycle.MONTHLY:
+    case BillingCycle.CUSTOM:
+    default:
+      return price * BILLING_CONVERSIONS.MONTHS_PER_YEAR;
+  }
+};
+
+/**
+ * Calculates subscription stats from a list of subscriptions.
+ *
+ * @param subscriptions - Array of subscriptions to calculate stats for.
+ * @param convertPrice - Optional currency converter. Receives (price, currency) and returns
+ *                       the price in the preferred currency. Defaults to identity (no conversion).
+ */
+export const calculateSubscriptionStats = (
+  subscriptions: Subscription[],
+  convertPrice: PriceConverter = (price) => price
+): SubscriptionStats => {
+  const empty: SubscriptionStats = {
+    totalActive: 0,
+    totalMonthlySpend: 0,
+    totalYearlySpend: 0,
+    categoryBreakdown: {} as Record<SubscriptionCategory, number>,
+  };
+
+  if (!subscriptions || !Array.isArray(subscriptions) || subscriptions.length === 0) {
+    return empty;
+  }
+
+  const activeSubs = subscriptions.filter((sub) => sub.isActive);
+
+  const totalMonthlySpend = activeSubs.reduce((total, sub) => {
+    const converted = convertPrice(sub.price, sub.currency);
+    return total + toMonthlyPrice(converted, sub.billingCycle);
+  }, 0);
+
+  const totalYearlySpend = activeSubs.reduce((total, sub) => {
+    const converted = convertPrice(sub.price, sub.currency);
+    return total + toYearlyPrice(converted, sub.billingCycle);
+  }, 0);
+
+  const categoryBreakdown = activeSubs.reduce(
+    (acc, sub) => {
+      acc[sub.category] = (acc[sub.category] || 0) + 1;
+      return acc;
+    },
+    {} as Record<SubscriptionCategory, number>
+  );
+
+  const totalGasSpent = activeSubs.reduce(
+    (total, sub) => total + (sub.totalGasSpent || 0),
+    0
+  );
+
+  return {
+    totalActive: activeSubs.length,
+    totalMonthlySpend,
+    totalYearlySpend,
+    categoryBreakdown,
+    totalGasSpent,
+  };
+};


### PR DESCRIPTION
refactor: extract shared subscription stats calculation utility

The stats calculation logic was duplicated between subscriptionStore.ts and dummyData.ts, with slightly different implementations — creating a risk of inconsistent results and double the maintenance burden.

Changes

stats.ts
 — new shared utility exposing toMonthlyPrice, toYearlyPrice, and calculateSubscriptionStats. Accepts an optional PriceConverter callback so callers can plug in currency conversion without coupling the utility to any service.
subscriptionStore.ts
 — replaced ~40 lines of inline reduce logic with a single calculateSubscriptionStats call, passing currencyService.convert as the converter.
dummyData.ts
 — getTotalMonthlySpending now delegates to toMonthlyPrice instead of its own switch block.
stats.test.ts
 — new tests covering empty/null input, inactive subscription filtering, all billing cycles, currency conversion, category breakdown, and gas spend aggregation.
Testing
npm test -- --testPathPattern="src/utils/__tests__/stats.test.ts" --no-coverage --watchAll=false


Closes #63 
