### PR TITLE
fix: remove unsafe as never type casts

### DIFF
--- a/src/services/segmentService.ts
+++ b/src/services/segmentService.ts
@@ -70,7 +70,7 @@ export class SegmentService {
         return fieldValue < targetValue;
       case CriteriaOperator.CONTAINS:
         if (Array.isArray(fieldValue)) {
-          return (fieldValue as unknown[]).includes(targetValue as never);
+          return (fieldValue as unknown[]).includes(targetValue);
         }
         if (typeof fieldValue === 'string') {
           return fieldValue.toLowerCase().includes(String(targetValue).toLowerCase());
@@ -78,7 +78,7 @@ export class SegmentService {
         return false;
       case CriteriaOperator.IN:
         if (Array.isArray(targetValue)) {
-          return (targetValue as unknown[]).includes(fieldValue as never);
+          return (targetValue as unknown[]).includes(fieldValue);
         }
         return false;
       case CriteriaOperator.STARTS_WITH:

--- a/src/store/_tests_/transactionQueueStore.test.ts
+++ b/src/store/_tests_/transactionQueueStore.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 import { ExecuteOrQueueResult, useTransactionQueueStore } from '../transactionQueueStore';
 
-const mockCreateSuperfluidStream = jest.fn();
+const mockCreateSuperfluidStream = jest.fn<Promise<{ streamId: string; txHash: string }>, unknown[]>();
 const mockCreateSablierStream = jest.fn();
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
@@ -85,7 +85,7 @@ describe('transactionQueueStore', () => {
     mockCreateSuperfluidStream.mockResolvedValue({
       streamId: 'stream:1',
       txHash: '0xhash',
-    } as never);
+    });
 
     await act(async () => {
       await useTransactionQueueStore.getState().queueTransaction(samplePayload);


### PR DESCRIPTION
## Description

Removes all \s never\ type casts from the codebase, replacing them with properly typed alternatives.

### Changes Made

**src/services/segmentService.ts**
- Removed \	argetValue as never\ and \ieldValue as never\ from \.includes()\ calls
- \unknown[]\ already accepts \unknown\ as parameter, so casts were unnecessary

**src/store/_tests_/transactionQueueStore.test.ts**
- Properly typed \mockCreateSuperfluidStream\ with jest generic parameters
- Removed \s never\ from mockResolvedValue return object

### Verification
- All \s never\ casts removed
- Runtime behavior unchanged

Closes #33