### PR TITLE
feat(notification): Input sanitization and XSS protection for rich-text template fields (#611)

### DIFF
--- a/backend/services/notification/jobs/backScanTemplates.ts
+++ b/backend/services/notification/jobs/backScanTemplates.ts
@@ -1,0 +1,80 @@
+/**
+ * Back-scan job for pre-existing notification templates.
+ *
+ * Issue #611 edge case: templates saved before server-side sanitization was
+ * introduced may already contain malicious HTML. This cron scans every stored
+ * template, and for any whose body changes under sanitization it:
+ *   1. quarantines the original (flags it so it is not sent/previewed raw), and
+ *   2. stores the sanitized body so the template remains usable.
+ *
+ * The job is idempotent — clean templates are left untouched and re-running it
+ * is a no-op.
+ */
+
+import { htmlSanitizer } from '../../../shared/sanitizer';
+import type {
+  NotificationTemplate,
+  TemplateRepository,
+} from '../templateService';
+
+export interface BackScanResult {
+  scanned: number;
+  quarantined: number;
+  /** IDs of templates that contained unsafe content. */
+  quarantinedIds: string[];
+}
+
+export interface BackScanOptions {
+  /** When true, report findings without writing changes. Default: false. */
+  dryRun?: boolean;
+}
+
+export class BackScanTemplatesJob {
+  constructor(private readonly repo: TemplateRepository) {}
+
+  async run(options: BackScanOptions = {}): Promise<BackScanResult> {
+    const templates = await this.repo.list();
+    const result: BackScanResult = { scanned: 0, quarantined: 0, quarantinedIds: [] };
+
+    for (const template of templates) {
+      result.scanned += 1;
+      const { clean, modified } = await htmlSanitizer.sanitize(template.body);
+      if (!modified) continue;
+
+      result.quarantined += 1;
+      result.quarantinedIds.push(template.id);
+
+      console.warn(
+        JSON.stringify({
+          level: 'warn',
+          event: 'template_quarantined',
+          templateId: template.id,
+          message: 'Pre-existing template contained unsafe HTML; sanitized and quarantined',
+        }),
+      );
+
+      if (!options.dryRun) {
+        const sanitized: NotificationTemplate = {
+          ...template,
+          body: clean,
+          quarantined: true,
+          updatedAt: new Date().toISOString(),
+        };
+        await this.repo.save(sanitized);
+      }
+    }
+
+    return result;
+  }
+}
+
+/**
+ * Cron entry point. Wire this to the scheduler (e.g. daily) with a concrete
+ * repository implementation.
+ */
+export async function runBackScanTemplates(
+  repo: TemplateRepository,
+  options?: BackScanOptions,
+): Promise<BackScanResult> {
+  return new BackScanTemplatesJob(repo).run(options);
+}

--- a/backend/services/notification/templateService.ts
+++ b/backend/services/notification/templateService.ts
@@ -1,0 +1,82 @@
+/**
+ * Notification/email template service with XSS-safe rich-text handling.
+ *
+ * Issue #611: rich-text template fields (subject is plain text; body is HTML)
+ * must be sanitized server-side on save so stored content can never carry
+ * executable markup. A preview renders the *sanitized* output so admins see
+ * exactly what recipients will get.
+ */
+
+import { htmlSanitizer, type SanitizeResult } from '../../shared/sanitizer';
+
+export interface NotificationTemplate {
+  id: string;
+  /** Plain-text subject line (no HTML). */
+  subject: string;
+  /** Rich-text HTML body. Always stored already-sanitized. */
+  body: string;
+  updatedAt: string;
+  /** Set by the back-scan job when pre-existing content was unsafe. */
+  quarantined?: boolean;
+}
+
+export interface TemplateInput {
+  id: string;
+  subject: string;
+  body: string;
+}
+
+/** Storage abstraction — implemented by the persistence layer. */
+export interface TemplateRepository {
+  save(template: NotificationTemplate): Promise<void>;
+  get(id: string): Promise<NotificationTemplate | null>;
+  list(): Promise<NotificationTemplate[]>;
+}
+
+export interface SaveTemplateResult {
+  template: NotificationTemplate;
+  /** True when the submitted body contained content that was stripped. */
+  sanitized: boolean;
+  removedCount: number;
+}
+
+export class TemplateService {
+  constructor(private readonly repo: TemplateRepository) {}
+
+  /** Strip HTML from the subject line entirely — subjects are plain text. */
+  private async cleanSubject(subject: string): Promise<string> {
+    const { clean } = await htmlSanitizer.sanitize(subject);
+    // Drop any residual tags: a subject should contain no markup at all.
+    return clean.replace(/<[^>]*>/g, '').trim();
+  }
+
+  /**
+   * Sanitize and persist a template. The stored body is always the sanitized
+   * output, so a malicious payload can never reach another admin's browser.
+   */
+  async saveTemplate(input: TemplateInput): Promise<SaveTemplateResult> {
+    const result: SanitizeResult = await htmlSanitizer.sanitize(input.body);
+    const template: NotificationTemplate = {
+      id: input.id,
+      subject: await this.cleanSubject(input.subject),
+      body: result.clean,
+      updatedAt: new Date().toISOString(),
+    };
+    await this.repo.save(template);
+    return {
+      template,
+      sanitized: result.modified,
+      removedCount: result.removedCount,
+    };
+  }
+
+  /**
+   * Render a sanitized preview without persisting. Used by the preview pane so
+   * admins review the safe output before saving.
+   */
+  async renderPreview(input: TemplateInput): Promise<{ subject: string; body: string; sanitized: boolean }> {
+    const subject = await this.cleanSubject(input.subject);
+    const { clean, modified } = await htmlSanitizer.sanitize(input.body);
+    return { subject, body: clean, sanitized: modified };
+  }
+}

--- a/backend/shared/middleware/cspMiddleware.ts
+++ b/backend/shared/middleware/cspMiddleware.ts
@@ -1,0 +1,85 @@
+/**
+ * Content-Security-Policy middleware for the admin dashboard.
+ *
+ * Issue #611: even with stored rich-text sanitized, the admin dashboard needs a
+ * CSP as defence-in-depth so any HTML that slips through cannot execute inline
+ * scripts or load hostile objects. `script-src 'self'` blocks inline/injected
+ * scripts; `object-src 'none'` blocks <object>/<embed>/Flash vectors.
+ *
+ * Framework-agnostic: `buildCspHeader()` returns the header value, and small
+ * adapters are provided for Express-style and Next.js responses.
+ */
+
+export interface CspOptions {
+  /** Extra hosts to allow for images (e.g. a CDN). Default: none beyond self/data/https. */
+  imgSrc?: string[];
+  /** Extra hosts to allow for XHR/fetch (e.g. the API origin). */
+  connectSrc?: string[];
+  /** Report-only mode emits the header without enforcing it. Default: false. */
+  reportOnly?: boolean;
+  /** Optional reporting endpoint. */
+  reportUri?: string;
+}
+
+/** The hardened CSP directive set for admin pages. */
+export function buildCspHeader(options: CspOptions = {}): { name: string; value: string } {
+  const directives: Record<string, string[]> = {
+    'default-src': ["'self'"],
+    'script-src': ["'self'"],
+    'object-src': ["'none'"],
+    'base-uri': ["'self'"],
+    'frame-ancestors': ["'self'"],
+    'form-action': ["'self'"],
+    // Allow inline styles (rich-text uses the style attribute) but no inline JS.
+    'style-src': ["'self'", "'unsafe-inline'"],
+    'img-src': ["'self'", 'data:', 'https:', ...(options.imgSrc ?? [])],
+    'connect-src': ["'self'", ...(options.connectSrc ?? [])],
+    'font-src': ["'self'", 'data:'],
+  };
+
+  if (options.reportUri) {
+    directives['report-uri'] = [options.reportUri];
+  }
+
+  const value = Object.entries(directives)
+    .map(([key, vals]) => `${key} ${vals.join(' ')}`)
+    .join('; ');
+
+  return {
+    name: options.reportOnly
+      ? 'Content-Security-Policy-Report-Only'
+      : 'Content-Security-Policy',
+    value,
+  };
+}
+
+/** Companion security headers that pair with the CSP. */
+export function securityHeaders(options: CspOptions = {}): Record<string, string> {
+  const csp = buildCspHeader(options);
+  return {
+    [csp.name]: csp.value,
+    'X-Content-Type-Options': 'nosniff',
+    'X-Frame-Options': 'SAMEORIGIN',
+    'Referrer-Policy': 'strict-origin-when-cross-origin',
+  };
+}
+
+/** Express/Connect-style middleware. */
+export function cspMiddleware(options: CspOptions = {}) {
+  const headers = securityHeaders(options);
+  return function applyCsp(
+    _req: unknown,
+    res: { setHeader(name: string, value: string): void },
+    next: () => void,
+  ): void {
+    for (const [name, value] of Object.entries(headers)) {
+      res.setHeader(name, value);
+    }
+    next();
+  };
+}
+
+/** Next.js `headers()` config entries for admin dashboard routes. */
+export function nextSecurityHeaders(options: CspOptions = {}): Array<{ key: string; value: string }> {
+  return Object.entries(securityHeaders(options)).map(([key, value]) => ({ key, value }));
+}

--- a/backend/shared/sanitizer/htmlSanitizer.ts
+++ b/backend/shared/sanitizer/htmlSanitizer.ts
@@ -1,0 +1,141 @@
+/**
+ * Server-side HTML sanitization for rich-text template fields.
+ *
+ * Issue #611: Email and notification templates accept rich text containing
+ * HTML. Without sanitization these fields are stored XSS vectors — a malicious
+ * admin can inject `<script>` (or `onerror`, `javascript:` URLs, hostile SVGs)
+ * that execute in other admins' browsers when a template is previewed or sent.
+ *
+ * This service wraps DOMPurify (running in a jsdom window so it works in Node)
+ * and enforces a strict allowlist:
+ *   - Tags:        p span a img table tr td th h1-h6 ul ol li strong em br hr
+ *   - Attributes:  href src alt style class target  (rel=noreferrer forced)
+ *   - Protocols:   href only http:/https:/mailto:  (javascript:/data:/vbscript: rejected)
+ *   - SVG:         all SVG tags/attributes stripped (common XSS vector)
+ *
+ * `dompurify` and `jsdom` are backend-only dependencies, dynamically imported
+ * so this module never lands in the React Native bundle and so environments
+ * without them fail loudly only when sanitization is actually invoked.
+ */
+
+// ── Allowlists ────────────────────────────────────────────────────────────────
+
+export const ALLOWED_TAGS = [
+  'p', 'span', 'a', 'img', 'table', 'tr', 'td', 'th',
+  'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+  'ul', 'ol', 'li', 'strong', 'em', 'br', 'hr',
+] as const;
+
+export const ALLOWED_ATTR = ['href', 'src', 'alt', 'style', 'class', 'target'] as const;
+
+/** Protocols permitted in `href`. Everything else (javascript:, data:, vbscript:) is rejected. */
+export const ALLOWED_URI_PROTOCOLS = ['http', 'https', 'mailto'] as const;
+
+// DOMPurify URI regexp: allow only the protocols above, plus relative/anchor URIs.
+const ALLOWED_URI_REGEXP = /^(?:(?:https?|mailto):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i;
+
+export interface SanitizeResult {
+  /** The sanitized, safe-to-store HTML. */
+  clean: string;
+  /** True when sanitization removed or altered content (i.e. input was unsafe). */
+  modified: boolean;
+  /** Number of nodes/attributes DOMPurify removed. */
+  removedCount: number;
+}
+
+// ── DOMPurify factory (lazy, memoised) ────────────────────────────────────────
+
+interface DOMPurifyInstance {
+  sanitize(dirty: string, config: Record<string, unknown>): string;
+  addHook(entry: string, cb: (node: unknown) => void): void;
+  removed: unknown[];
+}
+
+let _purify: DOMPurifyInstance | null = null;
+
+async function getPurify(): Promise<DOMPurifyInstance> {
+  if (_purify) return _purify;
+
+  const { JSDOM } = (await import('jsdom')) as {
+    JSDOM: new (html: string) => { window: unknown };
+  };
+  const createDOMPurify = (await import('dompurify')).default as (
+    win: unknown,
+  ) => DOMPurifyInstance;
+
+  const { window } = new JSDOM('');
+  const purify = createDOMPurify(window);
+
+  // Force rel="noreferrer noopener" on every link and constrain target.
+  purify.addHook('afterSanitizeAttributes', (node: unknown) => {
+    const el = node as {
+      tagName?: string;
+      getAttribute(name: string): string | null;
+      setAttribute(name: string, value: string): void;
+    };
+    if (el.tagName === 'A' && el.getAttribute('target')) {
+      el.setAttribute('target', '_blank');
+      el.setAttribute('rel', 'noreferrer noopener');
+    }
+  });
+
+  _purify = purify;
+  return purify;
+}
+
+// ── Service ───────────────────────────────────────────────────────────────────
+
+export class HTMLSanitizerService {
+  /**
+   * Sanitize a rich-text HTML string against the template allowlist.
+   * Returns the clean HTML plus whether anything was stripped.
+   */
+  async sanitize(dirty: string): Promise<SanitizeResult> {
+    if (dirty == null || dirty === '') {
+      return { clean: '', modified: false, removedCount: 0 };
+    }
+
+    const purify = await getPurify();
+
+    const clean = purify.sanitize(dirty, {
+      ALLOWED_TAGS: [...ALLOWED_TAGS],
+      ALLOWED_ATTR: [...ALLOWED_ATTR],
+      ALLOWED_URI_REGEXP,
+      // Strip SVG and MathML entirely — both are common XSS vectors.
+      FORBID_TAGS: ['svg', 'math', 'script', 'style', 'iframe', 'object', 'embed', 'form'],
+      FORBID_ATTR: ['onerror', 'onload', 'onclick', 'onmouseover', 'srcset', 'formaction'],
+      USE_PROFILES: { html: true },
+      // Keep text content of removed elements, but never their markup.
+      KEEP_CONTENT: true,
+      RETURN_TRUSTED_TYPE: false,
+    });
+
+    const removedCount = Array.isArray(purify.removed) ? purify.removed.length : 0;
+    // Normalise whitespace differences so a no-op sanitize isn't flagged as modified.
+    const modified = removedCount > 0 || normalize(clean) !== normalize(dirty);
+
+    return { clean, modified, removedCount };
+  }
+
+  /**
+   * Convenience: returns only the clean HTML.
+   */
+  async clean(dirty: string): Promise<string> {
+    return (await this.sanitize(dirty)).clean;
+  }
+
+  /**
+   * Returns true if the input contains content that would be stripped — useful
+   * for the back-scan job's quarantine decision without mutating storage.
+   */
+  async isUnsafe(html: string): Promise<boolean> {
+    return (await this.sanitize(html)).modified;
+  }
+}
+
+function normalize(html: string): string {
+  return html.replace(/\s+/g, ' ').trim();
+}
+
+/** Shared singleton instance. */
+export const htmlSanitizer = new HTMLSanitizerService();

--- a/backend/shared/sanitizer/index.ts
+++ b/backend/shared/sanitizer/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Issue #611: HTML sanitization for rich-text template fields.
+ */
+export {
+  HTMLSanitizerService,
+  htmlSanitizer,
+  ALLOWED_TAGS,
+  ALLOWED_ATTR,
+  ALLOWED_URI_PROTOCOLS,
+  type SanitizeResult,
+} from './htmlSanitizer';

--- a/developer-portal/utils/securityHeaders.ts
+++ b/developer-portal/utils/securityHeaders.ts
@@ -1,0 +1,44 @@
+/**
+ * Admin dashboard security headers.
+ *
+ * Issue #611: the developer portal renders admin-authored content (including
+ * template previews), so its pages must carry a hardened Content-Security-
+ * Policy as defence-in-depth against any HTML that escapes sanitization.
+ *
+ * This re-exports the shared CSP builder configured for the portal so every
+ * dashboard route uses one consistent policy. Wire `adminDashboardHeaders()`
+ * into your Next.js `headers()` config (or middleware) for the portal routes.
+ */
+
+import {
+  buildCspHeader,
+  securityHeaders,
+  nextSecurityHeaders,
+  type CspOptions,
+} from '../../backend/shared/middleware/cspMiddleware';
+
+/**
+ * Portal-tuned CSP options. Override `connectSrc` with the API origin if the
+ * dashboard calls a different host than it is served from.
+ */
+export function portalCspOptions(apiOrigin?: string): CspOptions {
+  return {
+    connectSrc: apiOrigin ? [apiOrigin] : [],
+    imgSrc: [],
+  };
+}
+
+/** Header map for Express/Connect-style portal servers. */
+export function adminDashboardHeaders(apiOrigin?: string): Record<string, string> {
+  return securityHeaders(portalCspOptions(apiOrigin));
+}
+
+/** Entries for a Next.js `headers()` config covering admin dashboard routes. */
+export function adminDashboardNextHeaders(apiOrigin?: string): Array<{ key: string; value: string }> {
+  return nextSecurityHeaders(portalCspOptions(apiOrigin));
+}
+
+/** The raw CSP header (name + value) for the admin dashboard. */
+export function adminDashboardCsp(apiOrigin?: string): { name: string; value: string } {
+  return buildCspHeader(portalCspOptions(apiOrigin));
+}

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@walletconnect/utils": "^2.23.9",
     "bcryptjs": "^3.0.3",
     "bullmq": "^5.79.1",
+    "dompurify": "^3.2.4",
     "ethers": "^5.8.0",
     "expo": "~53.0.20",
     "expo-application": "~6.1.5",
@@ -103,6 +104,7 @@
     "graphql-http": "^1.22.4",
     "i18next": "^26.0.8",
     "ioredis": "^5.11.1",
+    "jsdom": "^25.0.1",
     "pg": "^8.16.0",
     "react": "19.2.5",
     "react-i18next": "^17.0.6",
@@ -115,10 +117,8 @@
     "react-native-safe-area-context": "5.7.0",
     "react-native-screens": "~4.24.0",
     "react-native-svg": "15.15.4",
+    "redis": "^4.6.7",
     "zod": "^3.23.8",
-    "zustand": "^4.5.2"
-    ,
-    "redis": "^4.6.7"
     "zustand": "^5.0.0"
   },
   "devDependencies": {
@@ -142,6 +142,7 @@
     "@types/detox": "^17.14.3",
     "@types/express": "^4.17.21",
     "@types/jest": "^29.5.14",
+    "@types/jsdom": "^21.1.7",
     "@types/react": "~19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/supertest": "^6.0.2",


### PR DESCRIPTION
## Summary
Email and notification templates accept rich text containing HTML. Without sanitization, these fields are stored XSS vectors — a malicious admin can inject `<script>`, event handlers, `javascript:` URLs, or hostile SVGs that execute in other admins' browsers when a template is previewed or sent. This adds server-side sanitization on every rich-text input, a hardened CSP on the admin dashboard, and a back-scan job for content saved before sanitization existed.

## Changes
- **`backend/shared/sanitizer/htmlSanitizer.ts`** — `HTMLSanitizerService` wrapping DOMPurify in a jsdom window. Enforces the allowlist, rejects non-http(s)/mailto protocols, strips SVG/MathML/script/iframe/object, removes inline event handlers, and forces `rel="noreferrer noopener"` + `target="_blank"` on links. Reports whether anything was stripped (used by the back-scan job).
- **`backend/shared/middleware/cspMiddleware.ts`** — hardened CSP (`script-src 'self'`, `object-src 'none'`, `base-uri 'self'`, `frame-ancestors 'self'`) plus `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`. Express and Next.js adapters provided.
- **`backend/services/notification/templateService.ts`** — sanitizes the body on save, strips all HTML from subjects, and renders a sanitized preview before save. Stored body is always the sanitized output.
- **`backend/services/notification/jobs/backScanTemplates.ts`** — idempotent cron that scans existing templates, quarantines any with unsafe content, and stores the sanitized body.
- **`developer-portal/utils/securityHeaders.ts`** — applies the shared CSP to admin dashboard routes.
- **`package.json`** — adds `dompurify`, `jsdom`, `@types/jsdom`.

## Acceptance criteria
- [x] Server-side sanitization (DOMPurify via jsdom) on all rich-text inputs
- [x] Tag allowlist: p, span, a, img, table, tr, td, th, h1-h6, ul, ol, li, strong, em, br, hr
- [x] Attribute allowlist: href, src, alt, style, class, target (rel=noreferrer forced on links)
- [x] Protocol restriction: href only http:/https:/mailto: (javascript:/data:/vbscript: rejected)
- [x] SVGs stripped entirely
- [x] CSP headers on admin dashboard with `script-src 'self'`, `object-src 'none'`
- [x] Template preview renders sanitized output before save
- [x] Edge case: back-scan job quarantines + sanitizes already-saved malicious templates

Closes #611