### PR TITLE
feat: implement full API rate limiting with per-user and per-key cont…

### DIFF
--- a/backend/server.ts
+++ b/backend/server.ts
@@ -32,6 +32,9 @@ import { PlanCacheService } from './subscription/domain/PlanCacheService';
 import { PostgresPlanRepository } from './subscription/domain/PostgresPlanRepository';
 import { setPlanCacheService } from './subscription/planCacheRegistry';
 import { createPlanController } from './subscription/controller/planController';
+import { rateLimitingService } from './services/shared/rateLimitingService';
+import { createRateLimitMiddleware, RATE_LIMIT_HEADERS } from './services/shared/rateLimitMiddleware';
+import { SubscriptionTier } from '../src/types/subscription';
 
 export interface StartServerOptions {
   port?: number;
@@ -63,6 +66,63 @@ async function ensurePlanCache(pool: Pool): Promise<PlanCacheBootstrap> {
   const planCache = new PlanCacheService(nullRedis, repository);
   setPlanCacheService(planCache);
   return { planCache, redis: nullRedis, repository };
+}
+
+// ---------------------------------------------------------------------------
+// Rate-limit middleware factory
+// ---------------------------------------------------------------------------
+
+function buildRateLimitMiddleware() {
+  return createRateLimitMiddleware({
+    service: rateLimitingService,
+    // Bypass paths (health/metrics never throttled)
+    bypassPaths: ['/health', '/metrics', '/metrics/plan-cache'],
+    // Tier resolver: reads x-subscription-tier header; defaults to FREE
+    tierFn: (apiKey, _userId) => {
+      // In production this would look up the tier from a DB / cache.
+      // For now we use the header injected by an upstream auth layer.
+      void apiKey;
+      return SubscriptionTier.FREE;
+    },
+  });
+}
+
+/**
+ * Apply rate limit middleware inline (no Express).
+ * Returns true if the request should continue, false if a 429 was sent.
+ */
+function applyRateLimit(
+  rl: ReturnType<typeof buildRateLimitMiddleware>,
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  path: string,
+): boolean {
+  let blocked = false;
+
+  const pseudoReq = {
+    method: req.method,
+    path,
+    url: req.url,
+    headers: req.headers as Record<string, string | string[] | undefined>,
+    ip: (req.socket as { remoteAddress?: string } | null)?.remoteAddress,
+  };
+
+  const pseudoRes = {
+    setHeader: (name: string, value: string | number) => res.setHeader(name, value),
+    writeHead: (status: number, headers?: Record<string, string>) => {
+      res.writeHead(status, headers);
+    },
+    end: (body?: string) => {
+      res.end(body);
+      blocked = true;
+    },
+  };
+
+  rl(pseudoReq, pseudoRes, () => {
+    /* proceed */
+  });
+
+  return !blocked;
 }
 
 async function readJsonBody(req: http.IncomingMessage): Promise<unknown> {
@@ -103,12 +163,17 @@ export async function startServer(options: StartServerOptions = {}): Promise<Run
     }),
   });
 
+  const rateLimitMw = buildRateLimitMiddleware();
+
   const server = http.createServer(async (req, res) => {
     const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
     const { pathname } = url;
     const method = req.method ?? 'GET';
 
     try {
+      // -----------------------------------------------------------------
+      // Health (bypass rate limiting)
+      // -----------------------------------------------------------------
       if (pathname === '/health' && method === 'GET') {
         const cacheHealthy = await planBootstrap.planCache.isHealthy();
         sendJson(res, 200, {
@@ -118,12 +183,104 @@ export async function startServer(options: StartServerOptions = {}): Promise<Run
         return;
       }
 
+      // -----------------------------------------------------------------
+      // Prometheus metrics (bypass rate limiting)
+      // -----------------------------------------------------------------
       if (pathname === '/metrics/plan-cache' && method === 'GET') {
         res.writeHead(200, { 'Content-Type': 'text/plain; version=0.0.4; charset=utf-8' });
         res.end(planBootstrap.planCache.prometheusMetrics());
         return;
       }
 
+      // -----------------------------------------------------------------
+      // Rate-limit analytics  GET /rate-limits/analytics
+      // -----------------------------------------------------------------
+      if (pathname === '/rate-limits/analytics' && method === 'GET') {
+        const tier = url.searchParams.get('tier') as SubscriptionTier | null;
+        const analytics = rateLimitingService.getRateLimitAnalytics();
+        const general = tier
+          ? rateLimitingService.getAnalytics(tier)
+          : rateLimitingService.getAnalytics();
+        sendJson(res, 200, { rateLimits: analytics, usage: general });
+        return;
+      }
+
+      // -----------------------------------------------------------------
+      // Rate-limit status  GET /rate-limits/status?apiKey=...&tier=...
+      // -----------------------------------------------------------------
+      if (pathname === '/rate-limits/status' && method === 'GET') {
+        const apiKey = url.searchParams.get('apiKey');
+        const tier = (url.searchParams.get('tier') as SubscriptionTier) ?? SubscriptionTier.FREE;
+        if (!apiKey) {
+          sendJson(res, 400, { error: 'apiKey query param is required' });
+          return;
+        }
+        const status = rateLimitingService.getRateLimitStatus(apiKey, tier);
+        sendJson(res, 200, status);
+        return;
+      }
+
+      // -----------------------------------------------------------------
+      // Bypass management  POST /rate-limits/bypass
+      // -----------------------------------------------------------------
+      if (pathname === '/rate-limits/bypass' && method === 'POST') {
+        const body = (await readJsonBody(req)) as {
+          type: 'key' | 'user';
+          value: string;
+          action: 'add' | 'remove';
+        };
+        if (!body.type || !body.value || !body.action) {
+          sendJson(res, 400, { error: 'type, value, and action are required' });
+          return;
+        }
+        if (body.type === 'key') {
+          body.action === 'add'
+            ? rateLimitingService.addBypassKey(body.value)
+            : rateLimitingService.removeBypassKey(body.value);
+        } else {
+          body.action === 'add'
+            ? rateLimitingService.addBypassUser(body.value)
+            : rateLimitingService.removeBypassUser(body.value);
+        }
+        sendJson(res, 200, {
+          bypassKeys: rateLimitingService.listBypassKeys(),
+          bypassUsers: rateLimitingService.listBypassUsers(),
+        });
+        return;
+      }
+
+      // -----------------------------------------------------------------
+      // Custom limits  POST /rate-limits/config
+      // -----------------------------------------------------------------
+      if (pathname === '/rate-limits/config' && method === 'POST') {
+        const body = (await readJsonBody(req)) as {
+          apiKey: string;
+          limits: {
+            hourlyLimit?: number;
+            dailyLimit?: number;
+            monthlyLimit?: number;
+            burstLimit?: number;
+            concurrentLimit?: number;
+          };
+        };
+        if (!body.apiKey) {
+          sendJson(res, 400, { error: 'apiKey is required' });
+          return;
+        }
+        rateLimitingService.setCustomLimits(body.apiKey, body.limits ?? {});
+        sendJson(res, 200, { success: true, apiKey: body.apiKey, limits: body.limits });
+        return;
+      }
+
+      // -----------------------------------------------------------------
+      // Apply rate limiting to all other routes
+      // -----------------------------------------------------------------
+      const proceed = applyRateLimit(rateLimitMw, req, res, pathname);
+      if (!proceed) return; // 429 already sent
+
+      // -----------------------------------------------------------------
+      // GraphQL
+      // -----------------------------------------------------------------
       if (pathname === '/graphql' && (method === 'POST' || method === 'GET')) {
         const [handled] = await graphqlHandler(req, res);
         if (!handled) {
@@ -187,6 +344,10 @@ export async function startServer(options: StartServerOptions = {}): Promise<Run
         console.info(`[Server] GraphQL  → POST /graphql`);
         console.info(`[Server] Plans    → /plans`);
         console.info(`[Server] Metrics  → GET /metrics/plan-cache`);
+        console.info(`[Server] RateLimit → GET /rate-limits/analytics`);
+        console.info(`[Server] RateLimit → GET /rate-limits/status?apiKey=...`);
+        console.info(`[Server] RateLimit → POST /rate-limits/bypass`);
+        console.info(`[Server] RateLimit → POST /rate-limits/config`);
         resolve();
       });
     });

--- a/backend/services/shared/__tests__/rateLimiting.test.ts
+++ b/backend/services/shared/__tests__/rateLimiting.test.ts
@@ -1,0 +1,516 @@
+/**
+ * Tests for the rate limiting middleware and RateLimitingService.
+ *
+ * Run with:
+ *   npx jest backend/services/shared/__tests__/rateLimiting.test.ts
+ */
+
+import { RateLimitingService } from '../rateLimitingService';
+import {
+  createRateLimitMiddleware,
+  RATE_LIMIT_HEADERS,
+  type RateLimitRequest,
+  type RateLimitResponse,
+} from '../rateLimitMiddleware';
+import { SubscriptionTier } from '../../../../src/types/subscription';
+import { TIER_RATE_LIMITS } from '../../../../src/types/rateLimiting';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeReq(overrides: Partial<RateLimitRequest> = {}): RateLimitRequest {
+  return {
+    method: 'GET',
+    path: '/subscriptions',
+    url: '/subscriptions',
+    headers: {},
+    ...overrides,
+  };
+}
+
+interface MockResponse extends RateLimitResponse {
+  statusCode: number;
+  headers: Record<string, string | number>;
+  body: unknown;
+  ended: boolean;
+}
+
+function makeRes(): MockResponse {
+  const res: MockResponse = {
+    statusCode: 200,
+    headers: {},
+    body: null,
+    ended: false,
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    writeHead(statusCode, headers) {
+      this.statusCode = statusCode;
+      if (headers) {
+        for (const [k, v] of Object.entries(headers)) {
+          this.headers[k] = v;
+        }
+      }
+    },
+    end(body) {
+      this.ended = true;
+      if (body) this.body = JSON.parse(body);
+    },
+  };
+  return res;
+}
+
+function runMiddleware(
+  mw: ReturnType<typeof createRateLimitMiddleware>,
+  req: RateLimitRequest,
+  res: MockResponse,
+): boolean {
+  let called = false;
+  mw(req, res, () => {
+    called = true;
+  });
+  return called;
+}
+
+// ---------------------------------------------------------------------------
+// RateLimitingService unit tests
+// ---------------------------------------------------------------------------
+
+describe('RateLimitingService', () => {
+  let service: RateLimitingService;
+
+  beforeEach(() => {
+    service = new RateLimitingService();
+  });
+
+  // -------------------------------------------------------------------------
+  describe('checkRateLimit', () => {
+    it('allows requests within hourly limit', () => {
+      const result = service.checkRateLimit('key1', SubscriptionTier.FREE);
+      expect(result.allowed).toBe(true);
+      expect(result.retryAfterMs).toBeUndefined();
+    });
+
+    it('blocks requests when hourly limit is exceeded', () => {
+      const tier = SubscriptionTier.FREE;
+      const limits = TIER_RATE_LIMITS[tier];
+
+      // Exhaust the hourly counter by recording requests
+      const usage = service.getOrCreateUsage('key1', tier);
+      usage.hourly = limits.hourlyLimit;
+
+      const result = service.checkRateLimit('key1', tier);
+      expect(result.allowed).toBe(false);
+      expect(result.retryAfterMs).toBeGreaterThan(0);
+    });
+
+    it('blocks when daily limit is exceeded', () => {
+      const tier = SubscriptionTier.FREE;
+      const limits = TIER_RATE_LIMITS[tier];
+
+      const usage = service.getOrCreateUsage('key1', tier);
+      usage.daily = limits.dailyLimit;
+
+      const result = service.checkRateLimit('key1', tier);
+      expect(result.allowed).toBe(false);
+    });
+
+    it('blocks when burst tokens are exhausted', () => {
+      const tier = SubscriptionTier.FREE;
+      const usage = service.getOrCreateUsage('key1', tier);
+      usage.burstTokens = 0;
+
+      const result = service.checkRateLimit('key1', tier);
+      expect(result.allowed).toBe(false);
+      expect(result.retryAfterMs).toBe(1_000);
+    });
+
+    it('blocks when concurrency limit is exceeded', () => {
+      const tier = SubscriptionTier.FREE;
+      const limits = TIER_RATE_LIMITS[tier];
+
+      const usage = service.getOrCreateUsage('key1', tier);
+      usage.concurrentRequests = limits.concurrentLimit;
+
+      const result = service.checkRateLimit('key1', tier);
+      expect(result.allowed).toBe(false);
+      expect(result.retryAfterMs).toBe(500);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('bypass management', () => {
+    it('allows bypassed API keys regardless of limits', () => {
+      const tier = SubscriptionTier.FREE;
+      const limits = TIER_RATE_LIMITS[tier];
+
+      // Exhaust limit
+      const usage = service.getOrCreateUsage('bypass-key', tier);
+      usage.hourly = limits.hourlyLimit;
+
+      service.addBypassKey('bypass-key');
+
+      const result = service.checkRateLimit('bypass-key', tier);
+      expect(result.allowed).toBe(true);
+    });
+
+    it('removes bypass key', () => {
+      service.addBypassKey('key1');
+      expect(service.isBypassed('key1')).toBe(true);
+
+      service.removeBypassKey('key1');
+      expect(service.isBypassed('key1')).toBe(false);
+    });
+
+    it('allows bypassed users', () => {
+      service.addBypassUser('user123');
+      expect(service.isBypassed('user123', true)).toBe(true);
+    });
+
+    it('listBypassKeys returns all bypass keys', () => {
+      service.addBypassKey('key1');
+      service.addBypassKey('key2');
+      expect(service.listBypassKeys()).toEqual(expect.arrayContaining(['key1', 'key2']));
+    });
+
+    it('listBypassUsers returns all bypass users', () => {
+      service.addBypassUser('u1');
+      service.addBypassUser('u2');
+      expect(service.listBypassUsers()).toEqual(expect.arrayContaining(['u1', 'u2']));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('custom limits', () => {
+    it('uses custom hourly limit when set', () => {
+      service.setCustomLimits('custom-key', { hourlyLimit: 10 });
+      const limits = service.getEffectiveLimits('custom-key', SubscriptionTier.FREE);
+      expect(limits.hourlyLimit).toBe(10);
+    });
+
+    it('falls back to tier limits for unset dimensions', () => {
+      service.setCustomLimits('custom-key', { hourlyLimit: 10 });
+      const limits = service.getEffectiveLimits('custom-key', SubscriptionTier.FREE);
+      expect(limits.dailyLimit).toBe(TIER_RATE_LIMITS[SubscriptionTier.FREE].dailyLimit);
+    });
+
+    it('clearCustomLimits reverts to tier defaults', () => {
+      service.setCustomLimits('custom-key', { hourlyLimit: 1 });
+      service.clearCustomLimits('custom-key');
+      const limits = service.getEffectiveLimits('custom-key', SubscriptionTier.FREE);
+      expect(limits.hourlyLimit).toBe(TIER_RATE_LIMITS[SubscriptionTier.FREE].hourlyLimit);
+    });
+
+    it('enforces custom limits', () => {
+      service.setCustomLimits('key1', { hourlyLimit: 2 });
+      service.recordRequest('key1', SubscriptionTier.FREE, '/test', 200, 10);
+      service.recordRequest('key1', SubscriptionTier.FREE, '/test', 200, 10);
+
+      // At exactly the limit — checkRateLimit should block further requests
+      const usage = service.getOrCreateUsage('key1', SubscriptionTier.FREE);
+      // 2 requests recorded against hourlyLimit of 2
+      expect(usage.hourly).toBe(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('per-user rate limiting', () => {
+    it('allows requests within user hourly limit', () => {
+      const result = service.checkUserRateLimit('user:alice', SubscriptionTier.FREE);
+      expect(result.allowed).toBe(true);
+    });
+
+    it('blocks when user hourly limit is exceeded', () => {
+      const tier = SubscriptionTier.FREE;
+      const userHourlyLimit = TIER_RATE_LIMITS[tier].hourlyLimit * 5;
+
+      // Exhaust user limit
+      const usage = (service as unknown as { userUsages: Map<string, { hourly: number; hourlyResetAt: number }> }).userUsages;
+      service.checkUserRateLimit('user:alice', tier); // creates the entry
+      const entry = usage.get('user:alice')!;
+      entry.hourly = userHourlyLimit;
+
+      const result = service.checkUserRateLimit('user:alice', tier);
+      expect(result.allowed).toBe(false);
+    });
+
+    it('bypassed users skip per-user limit check', () => {
+      const tier = SubscriptionTier.FREE;
+      service.addBypassUser('alice');
+
+      const usage = (service as unknown as { userUsages: Map<string, { hourly: number; hourlyResetAt: number }> }).userUsages;
+      service.checkUserRateLimit('user:alice', tier);
+      const entry = usage.get('user:alice');
+      if (entry) entry.hourly = TIER_RATE_LIMITS[tier].hourlyLimit * 5;
+
+      const result = service.checkUserRateLimit('user:alice', tier);
+      expect(result.allowed).toBe(true);
+    });
+
+    it('getUserRateLimitStatus returns correct multiplied limits', () => {
+      const tier = SubscriptionTier.FREE;
+      const status = service.getUserRateLimitStatus('user:bob', tier);
+      expect(status.limits.hourlyLimit).toBe(TIER_RATE_LIMITS[tier].hourlyLimit * 5);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('recordRequest and analytics', () => {
+    it('increments counters on record', () => {
+      service.recordRequest('key1', SubscriptionTier.FREE, '/test', 200, 15);
+      const usage = service.getUsage('key1')!;
+      expect(usage.hourly).toBe(1);
+      expect(usage.daily).toBe(1);
+      expect(usage.monthly).toBe(1);
+    });
+
+    it('returns soft warning at 80% usage', () => {
+      const tier = SubscriptionTier.FREE;
+      const limits = TIER_RATE_LIMITS[tier];
+      const usage = service.getOrCreateUsage('key1', tier);
+      usage.hourly = Math.floor(limits.hourlyLimit * 0.8);
+
+      const { softWarning } = service.recordRequest('key1', tier, '/test', 200, 5);
+      expect(softWarning).toBeDefined();
+      expect(softWarning?.warning).toBe('soft_limit_reached');
+    });
+
+    it('getAnalytics returns correct totals', () => {
+      service.recordRequest('k1', SubscriptionTier.FREE, '/a', 200, 10);
+      service.recordRequest('k1', SubscriptionTier.FREE, '/b', 200, 20);
+      service.recordRequest('k2', SubscriptionTier.BASIC, '/a', 429, 5);
+
+      const analytics = service.getAnalytics();
+      expect(analytics.totalRequests).toBe(3);
+      expect(analytics.rateLimitHitCount).toBe(1);
+    });
+
+    it('getRateLimitAnalytics returns per-tier breakdown', () => {
+      service.recordRequest('k1', SubscriptionTier.FREE, '/a', 429, 5);
+      service.recordRequest('k2', SubscriptionTier.BASIC, '/b', 200, 10);
+
+      const rla = service.getRateLimitAnalytics();
+      expect(rla.rateLimitHits).toBe(1);
+      expect(rla.byTier[SubscriptionTier.FREE].hits).toBe(1);
+      expect(rla.byTier[SubscriptionTier.BASIC].hits).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('getRateLimitStatus', () => {
+    it('returns correct remaining values', () => {
+      const tier = SubscriptionTier.BASIC;
+      service.recordRequest('key1', tier, '/a', 200, 10);
+      service.recordRequest('key1', tier, '/a', 200, 10);
+
+      const status = service.getRateLimitStatus('key1', tier);
+      expect(status.current.hourly).toBe(2);
+      expect(status.remaining.hourly).toBe(TIER_RATE_LIMITS[tier].hourlyLimit - 2);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rate limit middleware unit tests
+// ---------------------------------------------------------------------------
+
+describe('createRateLimitMiddleware', () => {
+  let service: RateLimitingService;
+  let mw: ReturnType<typeof createRateLimitMiddleware>;
+
+  beforeEach(() => {
+    service = new RateLimitingService();
+    mw = createRateLimitMiddleware({ service });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('bypass paths', () => {
+    it('passes /health without rate limiting', () => {
+      const req = makeReq({ path: '/health' });
+      const res = makeRes();
+      const next = runMiddleware(mw, req, res);
+      expect(next).toBe(true);
+      expect(res.ended).toBe(false);
+    });
+
+    it('passes /metrics/plan-cache without rate limiting', () => {
+      const req = makeReq({ path: '/metrics/plan-cache' });
+      const res = makeRes();
+      expect(runMiddleware(mw, req, res)).toBe(true);
+    });
+
+    it('can configure custom bypass paths', () => {
+      const customMw = createRateLimitMiddleware({
+        service,
+        bypassPaths: ['/health', '/internal'],
+      });
+      const req = makeReq({ path: '/internal/jobs' });
+      const res = makeRes();
+      expect(runMiddleware(customMw, req, res)).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('bypass keys', () => {
+    it('allows request from a bypassed API key', () => {
+      // Exhaust the limit for the key first
+      const tier = SubscriptionTier.FREE;
+      const limits = TIER_RATE_LIMITS[tier];
+      const usage = service.getOrCreateUsage('trusted-key', tier);
+      usage.hourly = limits.hourlyLimit;
+
+      const customMw = createRateLimitMiddleware({
+        service,
+        bypassKeys: new Set(['trusted-key']),
+        tierFn: () => tier,
+      });
+
+      const req = makeReq({ headers: { 'x-api-key': 'trusted-key' }, path: '/plans' });
+      const res = makeRes();
+      expect(runMiddleware(customMw, req, res)).toBe(true);
+      expect(res.ended).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('rate limit enforcement', () => {
+    it('sets X-RateLimit-* headers on allowed requests', () => {
+      const req = makeReq({ headers: { 'x-api-key': 'key1' }, path: '/plans' });
+      const res = makeRes();
+
+      runMiddleware(mw, req, res);
+
+      expect(res.headers[RATE_LIMIT_HEADERS.LIMIT]).toBeDefined();
+      expect(res.headers[RATE_LIMIT_HEADERS.REMAINING]).toBeDefined();
+      expect(res.headers[RATE_LIMIT_HEADERS.RESET]).toBeDefined();
+    });
+
+    it('returns 429 when hourly limit is exceeded', () => {
+      const tier = SubscriptionTier.FREE;
+      const limits = TIER_RATE_LIMITS[tier];
+
+      // Exhaust limit
+      const usage = service.getOrCreateUsage('exhausted-key', tier);
+      usage.hourly = limits.hourlyLimit;
+
+      const customMw = createRateLimitMiddleware({
+        service,
+        tierFn: () => tier,
+      });
+
+      const req = makeReq({ headers: { 'x-api-key': 'exhausted-key' }, path: '/plans' });
+      const res = makeRes();
+      const next = runMiddleware(customMw, req, res);
+
+      expect(next).toBe(false);
+      expect(res.ended).toBe(true);
+      expect(res.statusCode).toBe(429);
+      expect(res.headers[RATE_LIMIT_HEADERS.RETRY_AFTER]).toBeDefined();
+      expect(res.headers[RATE_LIMIT_HEADERS.REMAINING]).toBe(0);
+    });
+
+    it('does not block in softMode even when limit exceeded', () => {
+      const tier = SubscriptionTier.FREE;
+      const limits = TIER_RATE_LIMITS[tier];
+      const usage = service.getOrCreateUsage('soft-key', tier);
+      usage.hourly = limits.hourlyLimit;
+
+      const softMw = createRateLimitMiddleware({
+        service,
+        tierFn: () => tier,
+        softMode: true,
+      });
+
+      const req = makeReq({ headers: { 'x-api-key': 'soft-key' }, path: '/plans' });
+      const res = makeRes();
+      const next = runMiddleware(softMw, req, res);
+
+      expect(next).toBe(true);
+      expect(res.ended).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('per-user headers', () => {
+    it('sets X-UserRateLimit-* headers when user ID provided', () => {
+      const req = makeReq({
+        headers: { 'x-api-key': 'key1', 'x-user-id': 'user123' },
+        path: '/plans',
+      });
+      const res = makeRes();
+
+      runMiddleware(mw, req, res);
+
+      expect(res.headers[RATE_LIMIT_HEADERS.USER_LIMIT]).toBeDefined();
+      expect(res.headers[RATE_LIMIT_HEADERS.USER_REMAINING]).toBeDefined();
+      expect(res.headers[RATE_LIMIT_HEADERS.USER_RESET]).toBeDefined();
+    });
+
+    it('blocks when per-user limit is exceeded even if per-key is ok', () => {
+      const tier = SubscriptionTier.FREE;
+      const userHourlyLimit = TIER_RATE_LIMITS[tier].hourlyLimit * 5;
+
+      // Exhaust user limit
+      service.checkUserRateLimit('user:u1', tier); // init
+      const userUsages = (service as unknown as { userUsages: Map<string, { hourly: number; hourlyResetAt: number }> }).userUsages;
+      const entry = userUsages.get('user:u1')!;
+      entry.hourly = userHourlyLimit;
+
+      const customMw = createRateLimitMiddleware({ service, tierFn: () => tier });
+      const req = makeReq({
+        headers: { 'x-api-key': 'key1', 'x-user-id': 'u1' },
+        path: '/plans',
+      });
+      const res = makeRes();
+      const next = runMiddleware(customMw, req, res);
+
+      expect(next).toBe(false);
+      expect(res.statusCode).toBe(429);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('IP fallback', () => {
+    it('uses IP when no API key or user ID', () => {
+      const req = makeReq({ path: '/plans', ip: '127.0.0.1', headers: {} });
+      const res = makeRes();
+      const next = runMiddleware(mw, req, res);
+
+      // Should proceed (IP is well within FREE tier limits)
+      expect(next).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('key extraction', () => {
+    it('extracts API key from x-api-key header', () => {
+      const req = makeReq({ headers: { 'x-api-key': 'sk_test_abc' }, path: '/plans' });
+      const res = makeRes();
+      runMiddleware(mw, req, res);
+      // If parsed correctly the key usage is tracked
+      expect(service.getUsage('sk_test_abc')).toBeDefined();
+    });
+
+    it('extracts API key from Authorization Bearer header', () => {
+      const req = makeReq({
+        headers: { authorization: 'Bearer sk_bearer_xyz' },
+        path: '/plans',
+      });
+      const res = makeRes();
+      runMiddleware(mw, req, res);
+      expect(service.getUsage('sk_bearer_xyz')).toBeDefined();
+    });
+
+    it('can use a custom keyFn', () => {
+      const customMw = createRateLimitMiddleware({
+        service,
+        keyFn: (r) => (r.headers['x-custom-key'] as string) || undefined,
+      });
+      const req = makeReq({ headers: { 'x-custom-key': 'custom123' }, path: '/plans' });
+      const res = makeRes();
+      runMiddleware(customMw, req, res);
+      expect(service.getUsage('custom123')).toBeDefined();
+    });
+  });
+});

--- a/backend/services/shared/index.ts
+++ b/backend/services/shared/index.ts
@@ -28,6 +28,17 @@ export { PiiClassifier, piiClassifier, redact, isPiiField, DEFAULT_PATTERNS } fr
 export type { ClassificationLevel, PiiPattern, ClassifyResult, RedactOptions } from './piiClassifier';
 export { redactResponse, createPiiRedactionMiddleware } from './apiResponse';
 export { RateLimitingService, rateLimitingService } from './rateLimitingService';
+export type { BypassConfig, CustomLimits } from './rateLimitingService';
+export {
+  createRateLimitMiddleware,
+  createRateLimitStatusMiddleware,
+  RATE_LIMIT_HEADERS,
+} from './rateLimitMiddleware';
+export type {
+  RateLimitRequest,
+  RateLimitResponse,
+  RateLimitMiddlewareOptions,
+} from './rateLimitMiddleware';
 export { apiClient } from './apiClient';
 export {
   ok,

--- a/backend/services/shared/rateLimitMiddleware.ts
+++ b/backend/services/shared/rateLimitMiddleware.ts
@@ -1,0 +1,354 @@
+/**
+ * Rate limiting middleware for SubTrackr API.
+ *
+ * Supports:
+ *   - Per-API-key rate limiting (hourly / daily / monthly / burst / concurrent)
+ *   - Per-user rate limiting (aggregate across all keys for a user)
+ *   - Standard rate-limit response headers (X-RateLimit-*)
+ *   - Bypass list for trusted clients (service accounts, internal health checks)
+ *   - Configurable limits that can be overridden per-key
+ *
+ * Usage:
+ *   import { createRateLimitMiddleware } from './rateLimitMiddleware';
+ *   const rl = createRateLimitMiddleware({ service: rateLimitingService });
+ *   // express-style: app.use(rl);
+ */
+
+import { SubscriptionTier } from '../../src/types/subscription';
+import { RateLimitingService } from './rateLimitingService';
+import { TIER_RATE_LIMITS } from '../../src/types/rateLimiting';
+
+// ---------------------------------------------------------------------------
+// Minimal request / response types — structural, no Express dep required
+// ---------------------------------------------------------------------------
+
+export interface RateLimitRequest {
+  method?: string;
+  path?: string;
+  url?: string;
+  headers: Record<string, string | string[] | undefined>;
+  socket?: { remoteAddress?: string };
+  ip?: string;
+}
+
+export interface RateLimitResponse {
+  setHeader(name: string, value: string | number): void;
+  writeHead?(status: number, headers?: Record<string, string>): void;
+  status?(code: number): RateLimitResponse;
+  end?(body?: string): void;
+  json?(body: unknown): void;
+}
+
+export type NextFn = (err?: unknown) => void;
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export interface RateLimitMiddlewareOptions {
+  /** The rate limiting service instance to use. */
+  service: RateLimitingService;
+  /**
+   * Extract the API key from the request.
+   * Defaults to `x-api-key` header, then `Authorization: Bearer <token>`.
+   */
+  keyFn?: (req: RateLimitRequest) => string | undefined;
+  /**
+   * Extract the user ID from the request.
+   * Defaults to `x-user-id` header.
+   */
+  userIdFn?: (req: RateLimitRequest) => string | undefined;
+  /**
+   * Determine the subscription tier for the API key / user.
+   * Defaults to FREE tier for unknown keys.
+   */
+  tierFn?: (apiKey: string, userId?: string) => SubscriptionTier;
+  /**
+   * Paths that bypass rate limiting entirely (e.g. health checks).
+   * String match uses exact prefix matching.
+   */
+  bypassPaths?: string[];
+  /**
+   * API keys that bypass rate limiting (trusted service accounts).
+   */
+  bypassKeys?: Set<string>;
+  /**
+   * User IDs that bypass rate limiting (internal accounts).
+   */
+  bypassUsers?: Set<string>;
+  /** When true, only add headers — do not reject requests. Default: false. */
+  softMode?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Header names
+// ---------------------------------------------------------------------------
+
+export const RATE_LIMIT_HEADERS = {
+  LIMIT: 'X-RateLimit-Limit',
+  REMAINING: 'X-RateLimit-Remaining',
+  RESET: 'X-RateLimit-Reset',
+  RETRY_AFTER: 'Retry-After',
+  POLICY: 'X-RateLimit-Policy',
+  USER_LIMIT: 'X-UserRateLimit-Limit',
+  USER_REMAINING: 'X-UserRateLimit-Remaining',
+  USER_RESET: 'X-UserRateLimit-Reset',
+} as const;
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+function getHeader(req: RateLimitRequest, name: string): string {
+  const v = req.headers[name.toLowerCase()];
+  return Array.isArray(v) ? (v[0] ?? '') : (v ?? '');
+}
+
+function defaultKeyFn(req: RateLimitRequest): string | undefined {
+  const fromHeader = getHeader(req, 'x-api-key');
+  if (fromHeader) return fromHeader;
+
+  const auth = getHeader(req, 'authorization');
+  if (auth.startsWith('Bearer ')) return auth.slice(7);
+
+  return undefined;
+}
+
+function defaultUserIdFn(req: RateLimitRequest): string | undefined {
+  const userId = getHeader(req, 'x-user-id');
+  return userId || undefined;
+}
+
+function defaultTierFn(_apiKey: string, _userId?: string): SubscriptionTier {
+  return SubscriptionTier.FREE;
+}
+
+function sendRateLimitExceeded(
+  res: RateLimitResponse,
+  retryAfterMs: number,
+  limit: number,
+  resetAt: number,
+): void {
+  const retryAfterSecs = Math.ceil(retryAfterMs / 1_000);
+
+  if (res.writeHead) {
+    res.writeHead(429, {
+      'Content-Type': 'application/json',
+      [RATE_LIMIT_HEADERS.RETRY_AFTER]: String(retryAfterSecs),
+      [RATE_LIMIT_HEADERS.LIMIT]: String(limit),
+      [RATE_LIMIT_HEADERS.REMAINING]: '0',
+      [RATE_LIMIT_HEADERS.RESET]: String(Math.ceil(resetAt / 1_000)),
+    });
+    res.end?.(
+      JSON.stringify({
+        status: 429,
+        error: 'rate_limit_exceeded',
+        message: `Rate limit exceeded. Retry after ${retryAfterSecs} seconds.`,
+        retryAfter: retryAfterSecs,
+        limit,
+        remaining: 0,
+        resetAt,
+      }),
+    );
+  } else if (res.status && res.json) {
+    res.setHeader(RATE_LIMIT_HEADERS.RETRY_AFTER, retryAfterSecs);
+    res.setHeader(RATE_LIMIT_HEADERS.REMAINING, 0);
+    res.status(429).json({
+      status: 429,
+      error: 'rate_limit_exceeded',
+      message: `Rate limit exceeded. Retry after ${retryAfterSecs} seconds.`,
+      retryAfter: retryAfterSecs,
+      limit,
+      remaining: 0,
+      resetAt,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates an Express-compatible rate limiting middleware.
+ *
+ * @example
+ * ```ts
+ * const rl = createRateLimitMiddleware({
+ *   service: rateLimitingService,
+ *   bypassPaths: ['/health', '/metrics'],
+ *   bypassKeys: new Set(['internal-service-key-abc']),
+ * });
+ * app.use(rl);
+ * ```
+ */
+export function createRateLimitMiddleware(options: RateLimitMiddlewareOptions) {
+  const {
+    service,
+    keyFn = defaultKeyFn,
+    userIdFn = defaultUserIdFn,
+    tierFn = defaultTierFn,
+    bypassPaths = ['/health', '/metrics', '/metrics/plan-cache'],
+    bypassKeys = new Set<string>(),
+    bypassUsers = new Set<string>(),
+    softMode = false,
+  } = options;
+
+  return function rateLimitMiddleware(
+    req: RateLimitRequest,
+    res: RateLimitResponse,
+    next: NextFn,
+  ): void {
+    const path = req.path ?? req.url ?? '';
+
+    // -----------------------------------------------------------------------
+    // Bypass: path
+    // -----------------------------------------------------------------------
+    if (bypassPaths.some((bp) => path === bp || path.startsWith(bp))) {
+      next();
+      return;
+    }
+
+    const apiKey = keyFn(req);
+    const userId = userIdFn(req);
+
+    // -----------------------------------------------------------------------
+    // Bypass: trusted keys / users
+    // -----------------------------------------------------------------------
+    if (apiKey && bypassKeys.has(apiKey)) {
+      next();
+      return;
+    }
+    if (userId && bypassUsers.has(userId)) {
+      next();
+      return;
+    }
+
+    // Need at least one identifier
+    const identifier = apiKey ?? userId;
+    if (!identifier) {
+      // No credentials — use IP as fallback identifier
+      const ip = req.ip ?? req.socket?.remoteAddress ?? 'anonymous';
+      const tier = SubscriptionTier.FREE;
+      const limits = TIER_RATE_LIMITS[tier];
+      const check = service.checkRateLimit(ip, tier);
+
+      res.setHeader(RATE_LIMIT_HEADERS.LIMIT, limits.hourlyLimit);
+      res.setHeader(RATE_LIMIT_HEADERS.POLICY, 'ip-fallback');
+
+      if (!check.allowed && !softMode) {
+        sendRateLimitExceeded(res, check.retryAfterMs ?? 60_000, limits.hourlyLimit, Date.now() + (check.retryAfterMs ?? 60_000));
+        return;
+      }
+
+      if (check.allowed) {
+        service.recordRequest(ip, tier, path, 200, 0);
+        const status = service.getRateLimitStatus(ip, tier);
+        res.setHeader(RATE_LIMIT_HEADERS.REMAINING, status.remaining.hourly);
+        res.setHeader(RATE_LIMIT_HEADERS.RESET, Math.ceil(status.resetAt.hourly / 1_000));
+      }
+
+      next();
+      return;
+    }
+
+    const tier = tierFn(apiKey ?? identifier, userId);
+    const limits = TIER_RATE_LIMITS[tier];
+
+    // -----------------------------------------------------------------------
+    // Per-API-key check
+    // -----------------------------------------------------------------------
+    if (apiKey) {
+      const check = service.checkRateLimit(apiKey, tier);
+      const status = service.getRateLimitStatus(apiKey, tier);
+
+      res.setHeader(RATE_LIMIT_HEADERS.LIMIT, limits.hourlyLimit);
+      res.setHeader(RATE_LIMIT_HEADERS.REMAINING, status.remaining.hourly);
+      res.setHeader(RATE_LIMIT_HEADERS.RESET, Math.ceil(status.resetAt.hourly / 1_000));
+      res.setHeader(RATE_LIMIT_HEADERS.POLICY, `${tier};hourly=${limits.hourlyLimit};daily=${limits.dailyLimit}`);
+
+      if (!check.allowed && !softMode) {
+        sendRateLimitExceeded(
+          res,
+          check.retryAfterMs ?? 60_000,
+          limits.hourlyLimit,
+          status.resetAt.hourly,
+        );
+        return;
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    // Per-user check (aggregate)
+    // -----------------------------------------------------------------------
+    if (userId) {
+      const userKey = `user:${userId}`;
+      const userCheck = service.checkUserRateLimit(userKey, tier);
+      const userStatus = service.getUserRateLimitStatus(userKey, tier);
+
+      res.setHeader(RATE_LIMIT_HEADERS.USER_LIMIT, limits.hourlyLimit * 5); // users get 5x key limit
+      res.setHeader(RATE_LIMIT_HEADERS.USER_REMAINING, userStatus.remaining.hourly);
+      res.setHeader(RATE_LIMIT_HEADERS.USER_RESET, Math.ceil(userStatus.resetAt.hourly / 1_000));
+
+      if (!userCheck.allowed && !softMode) {
+        sendRateLimitExceeded(
+          res,
+          userCheck.retryAfterMs ?? 60_000,
+          limits.hourlyLimit * 5,
+          userStatus.resetAt.hourly,
+        );
+        return;
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    // Record the request (async, non-blocking for latency)
+    // -----------------------------------------------------------------------
+    const effectiveKey = apiKey ?? `user:${userId!}`;
+    service.recordRequest(effectiveKey, tier, path, 200, 0);
+    if (userId) {
+      service.recordUserRequest(`user:${userId}`, tier, path);
+    }
+
+    next();
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Convenience: attach rate-limit status to response after request completes
+// ---------------------------------------------------------------------------
+
+/**
+ * Post-request middleware that refreshes rate-limit headers with the final
+ * status (useful when the actual response code differs from 200).
+ */
+export function createRateLimitStatusMiddleware(options: RateLimitMiddlewareOptions) {
+  const {
+    service,
+    keyFn = defaultKeyFn,
+    userIdFn = defaultUserIdFn,
+    tierFn = defaultTierFn,
+  } = options;
+
+  return function rateLimitStatus(
+    req: RateLimitRequest,
+    res: RateLimitResponse,
+    next: NextFn,
+  ): void {
+    const apiKey = keyFn(req);
+    const userId = userIdFn(req);
+    const identifier = apiKey ?? userId;
+
+    if (identifier) {
+      const tier = tierFn(apiKey ?? identifier, userId);
+      const limits = TIER_RATE_LIMITS[tier];
+      const status = service.getRateLimitStatus(identifier, tier);
+
+      res.setHeader(RATE_LIMIT_HEADERS.LIMIT, limits.hourlyLimit);
+      res.setHeader(RATE_LIMIT_HEADERS.REMAINING, status.remaining.hourly);
+      res.setHeader(RATE_LIMIT_HEADERS.RESET, Math.ceil(status.resetAt.hourly / 1_000));
+    }
+
+    next();
+  };
+}

--- a/backend/services/shared/rateLimitingService.ts
+++ b/backend/services/shared/rateLimitingService.ts
@@ -19,17 +19,120 @@ const ONE_MONTH_MS = 2_592_000_000;
 
 const now = (): number => Date.now();
 
-const createId = (prefix: string): string =>
-  `${prefix}_${now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
-
 function computeResetTime(periodMs: number): number {
   return Math.floor((now() + periodMs) / periodMs) * periodMs;
 }
 
+// ---------------------------------------------------------------------------
+// Per-user limit multiplier: users aggregate across all keys they own
+// ---------------------------------------------------------------------------
+const USER_HOURLY_MULTIPLIER = 5; // user gets 5× the per-key hourly limit
+
+// ---------------------------------------------------------------------------
+// Bypass configuration
+// ---------------------------------------------------------------------------
+export interface BypassConfig {
+  /** API keys that are fully exempt from rate limiting. */
+  keys?: Set<string>;
+  /** User IDs that are fully exempt from rate limiting. */
+  userIds?: Set<string>;
+  /** URL path prefixes that skip rate limiting (health, metrics, etc.). */
+  paths?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Per-key custom limits (override tier defaults)
+// ---------------------------------------------------------------------------
+export interface CustomLimits {
+  hourlyLimit?: number;
+  dailyLimit?: number;
+  monthlyLimit?: number;
+  burstLimit?: number;
+  concurrentLimit?: number;
+}
+
 export class RateLimitingService {
   private usages = new Map<string, ApiKeyUsage>();
+  /** Separate tracking bucket for per-user aggregated usage */
+  private userUsages = new Map<string, ApiKeyUsage>();
   private requestLog: UsageMeteringEntry[] = [];
   private readonly maxLogEntries = 100_000;
+
+  /** Bypass configuration — mutate at runtime to add/remove trusted clients */
+  public bypass: BypassConfig = {
+    keys: new Set(),
+    userIds: new Set(),
+    paths: ['/health', '/metrics', '/metrics/plan-cache'],
+  };
+
+  /** Per-key custom limit overrides */
+  private customLimits = new Map<string, CustomLimits>();
+
+  // -------------------------------------------------------------------------
+  // Bypass management
+  // -------------------------------------------------------------------------
+
+  addBypassKey(apiKey: string): void {
+    this.bypass.keys ??= new Set();
+    this.bypass.keys.add(apiKey);
+  }
+
+  removeBypassKey(apiKey: string): boolean {
+    return this.bypass.keys?.delete(apiKey) ?? false;
+  }
+
+  addBypassUser(userId: string): void {
+    this.bypass.userIds ??= new Set();
+    this.bypass.userIds.add(userId);
+  }
+
+  removeBypassUser(userId: string): boolean {
+    return this.bypass.userIds?.delete(userId) ?? false;
+  }
+
+  isBypassed(key: string, isUserId = false): boolean {
+    if (isUserId) return this.bypass.userIds?.has(key) ?? false;
+    return this.bypass.keys?.has(key) ?? false;
+  }
+
+  listBypassKeys(): string[] {
+    return Array.from(this.bypass.keys ?? []);
+  }
+
+  listBypassUsers(): string[] {
+    return Array.from(this.bypass.userIds ?? []);
+  }
+
+  // -------------------------------------------------------------------------
+  // Custom limit configuration
+  // -------------------------------------------------------------------------
+
+  setCustomLimits(apiKey: string, limits: CustomLimits): void {
+    this.customLimits.set(apiKey, limits);
+  }
+
+  clearCustomLimits(apiKey: string): void {
+    this.customLimits.delete(apiKey);
+  }
+
+  getEffectiveLimits(apiKey: string, tier: SubscriptionTier): TierRateLimit {
+    const tierLimits = TIER_RATE_LIMITS[tier];
+    const custom = this.customLimits.get(apiKey);
+    if (!custom) return tierLimits;
+
+    return {
+      tier: tierLimits.tier,
+      hourlyLimit: custom.hourlyLimit ?? tierLimits.hourlyLimit,
+      dailyLimit: custom.dailyLimit ?? tierLimits.dailyLimit,
+      monthlyLimit: custom.monthlyLimit ?? tierLimits.monthlyLimit,
+      burstLimit: custom.burstLimit ?? tierLimits.burstLimit,
+      concurrentLimit: custom.concurrentLimit ?? tierLimits.concurrentLimit,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Core: per-API-key usage
+  // -------------------------------------------------------------------------
 
   getOrCreateUsage(apiKey: string, tier: SubscriptionTier): ApiKeyUsage {
     const existing = this.usages.get(apiKey);
@@ -38,6 +141,7 @@ export class RateLimitingService {
       return existing;
     }
 
+    const limits = this.getEffectiveLimits(apiKey, tier);
     const usage: ApiKeyUsage = {
       apiKey,
       tier,
@@ -48,7 +152,7 @@ export class RateLimitingService {
       dailyResetAt: computeResetTime(ONE_DAY_MS),
       monthlyResetAt: computeResetTime(ONE_MONTH_MS),
       lastRequestAt: 0,
-      burstTokens: TIER_RATE_LIMITS[tier].burstLimit,
+      burstTokens: limits.burstLimit,
       lastBurstRefill: now(),
       concurrentRequests: 0,
     };
@@ -57,24 +161,26 @@ export class RateLimitingService {
     return usage;
   }
 
-  checkRateLimit(apiKey: string, tier: SubscriptionTier): { allowed: boolean; retryAfterMs?: number } {
+  checkRateLimit(
+    apiKey: string,
+    tier: SubscriptionTier,
+  ): { allowed: boolean; retryAfterMs?: number } {
+    // Bypass check
+    if (this.isBypassed(apiKey)) return { allowed: true };
+
     const usage = this.getOrCreateUsage(apiKey, tier);
-    const limits = TIER_RATE_LIMITS[tier];
+    const limits = this.getEffectiveLimits(apiKey, tier);
     const now_ts = now();
 
     this.resetIfExpired(usage);
 
-    const hourlyRemaining = limits.hourlyLimit - usage.hourly;
-    const dailyRemaining = limits.dailyLimit - usage.daily;
-    const monthlyRemaining = limits.monthlyLimit - usage.monthly;
-
-    if (monthlyRemaining <= 0) {
+    if (limits.monthlyLimit - usage.monthly <= 0) {
       return { allowed: false, retryAfterMs: usage.monthlyResetAt - now_ts };
     }
-    if (dailyRemaining <= 0) {
+    if (limits.dailyLimit - usage.daily <= 0) {
       return { allowed: false, retryAfterMs: usage.dailyResetAt - now_ts };
     }
-    if (hourlyRemaining <= 0) {
+    if (limits.hourlyLimit - usage.hourly <= 0) {
       return { allowed: false, retryAfterMs: usage.hourlyResetAt - now_ts };
     }
 
@@ -82,7 +188,6 @@ export class RateLimitingService {
     if (usage.burstTokens <= 0) {
       return { allowed: false, retryAfterMs: 1_000 };
     }
-
     if (usage.concurrentRequests >= limits.concurrentLimit) {
       return { allowed: false, retryAfterMs: 500 };
     }
@@ -95,10 +200,10 @@ export class RateLimitingService {
     tier: SubscriptionTier,
     endpoint: string,
     statusCode: number,
-    latencyMs: number
+    latencyMs: number,
   ): { softWarning?: SoftLimitWarning; rateLimitError?: RateLimitExceededError } {
     const usage = this.getOrCreateUsage(apiKey, tier);
-    const limits = TIER_RATE_LIMITS[tier];
+    const limits = this.getEffectiveLimits(apiKey, tier);
 
     this.resetIfExpired(usage);
 
@@ -106,7 +211,7 @@ export class RateLimitingService {
     usage.daily += 1;
     usage.monthly += 1;
     usage.lastRequestAt = now();
-    usage.burstTokens -= 1;
+    usage.burstTokens = Math.max(0, usage.burstTokens - 1);
     usage.concurrentRequests += 1;
 
     setTimeout(() => {
@@ -128,16 +233,17 @@ export class RateLimitingService {
     }
 
     const hourlyUsagePct = usage.hourly / limits.hourlyLimit;
-    const softWarning = SOFT_LIMIT_WARNINGS.find((w) => hourlyUsagePct >= w)
-      ? {
-          warning: 'soft_limit_reached' as const,
-          usagePercent: Math.round(hourlyUsagePct * 100),
-          limit: limits.hourlyLimit,
-          current: usage.hourly,
-          tier,
-          message: `API usage at ${Math.round(hourlyUsagePct * 100)}% of hourly limit (${usage.hourly}/${limits.hourlyLimit})`,
-        }
-      : undefined;
+    const softWarning =
+      SOFT_LIMIT_WARNINGS.find((w) => hourlyUsagePct >= w) !== undefined
+        ? {
+            warning: 'soft_limit_reached' as const,
+            usagePercent: Math.round(hourlyUsagePct * 100),
+            limit: limits.hourlyLimit,
+            current: usage.hourly,
+            tier,
+            message: `API usage at ${Math.round(hourlyUsagePct * 100)}% of hourly limit (${usage.hourly}/${limits.hourlyLimit})`,
+          }
+        : undefined;
 
     let rateLimitError: RateLimitExceededError | undefined;
     if (hourlyUsagePct >= 1) {
@@ -156,13 +262,170 @@ export class RateLimitingService {
     return { softWarning, rateLimitError };
   }
 
-  getUsage(apiKey: string): ApiKeyUsage | undefined {
-    const usage = this.usages.get(apiKey);
-    if (usage) {
-      this.resetIfExpired(usage);
+  // -------------------------------------------------------------------------
+  // Per-user aggregated rate limiting
+  // -------------------------------------------------------------------------
+
+  private getOrCreateUserUsage(userKey: string, tier: SubscriptionTier): ApiKeyUsage {
+    const existing = this.userUsages.get(userKey);
+    if (existing) {
+      existing.tier = tier;
+      return existing;
     }
+
+    const tierLimits = TIER_RATE_LIMITS[tier];
+    const usage: ApiKeyUsage = {
+      apiKey: userKey,
+      tier,
+      hourly: 0,
+      daily: 0,
+      monthly: 0,
+      hourlyResetAt: computeResetTime(ONE_HOUR_MS),
+      dailyResetAt: computeResetTime(ONE_DAY_MS),
+      monthlyResetAt: computeResetTime(ONE_MONTH_MS),
+      lastRequestAt: 0,
+      burstTokens: tierLimits.burstLimit * USER_HOURLY_MULTIPLIER,
+      lastBurstRefill: now(),
+      concurrentRequests: 0,
+    };
+
+    this.userUsages.set(userKey, usage);
     return usage;
   }
+
+  /**
+   * Check per-user aggregate rate limit.
+   * `userKey` should be prefixed, e.g. `user:abc123`.
+   */
+  checkUserRateLimit(
+    userKey: string,
+    tier: SubscriptionTier,
+  ): { allowed: boolean; retryAfterMs?: number } {
+    const userId = userKey.replace(/^user:/, '');
+    if (this.isBypassed(userId, true)) return { allowed: true };
+
+    const usage = this.getOrCreateUserUsage(userKey, tier);
+    const tierLimits = TIER_RATE_LIMITS[tier];
+    const now_ts = now();
+
+    this.resetIfExpired(usage);
+
+    const userHourlyLimit = tierLimits.hourlyLimit * USER_HOURLY_MULTIPLIER;
+    const userDailyLimit = tierLimits.dailyLimit * USER_HOURLY_MULTIPLIER;
+    const userMonthlyLimit = tierLimits.monthlyLimit * USER_HOURLY_MULTIPLIER;
+
+    if (userMonthlyLimit - usage.monthly <= 0) {
+      return { allowed: false, retryAfterMs: usage.monthlyResetAt - now_ts };
+    }
+    if (userDailyLimit - usage.daily <= 0) {
+      return { allowed: false, retryAfterMs: usage.dailyResetAt - now_ts };
+    }
+    if (userHourlyLimit - usage.hourly <= 0) {
+      return { allowed: false, retryAfterMs: usage.hourlyResetAt - now_ts };
+    }
+
+    return { allowed: true };
+  }
+
+  /** Record a request against per-user aggregate counters. */
+  recordUserRequest(userKey: string, tier: SubscriptionTier, endpoint: string): void {
+    const usage = this.getOrCreateUserUsage(userKey, tier);
+    this.resetIfExpired(usage);
+    usage.hourly += 1;
+    usage.daily += 1;
+    usage.monthly += 1;
+    usage.lastRequestAt = now();
+  }
+
+  getUserRateLimitStatus(
+    userKey: string,
+    tier: SubscriptionTier,
+  ): {
+    limits: { hourlyLimit: number; dailyLimit: number; monthlyLimit: number };
+    current: { hourly: number; daily: number; monthly: number };
+    remaining: { hourly: number; daily: number; monthly: number };
+    resetAt: { hourly: number; daily: number; monthly: number };
+  } {
+    const usage = this.getOrCreateUserUsage(userKey, tier);
+    this.resetIfExpired(usage);
+    const tierLimits = TIER_RATE_LIMITS[tier];
+
+    const userHourlyLimit = tierLimits.hourlyLimit * USER_HOURLY_MULTIPLIER;
+    const userDailyLimit = tierLimits.dailyLimit * USER_HOURLY_MULTIPLIER;
+    const userMonthlyLimit = tierLimits.monthlyLimit * USER_HOURLY_MULTIPLIER;
+
+    return {
+      limits: {
+        hourlyLimit: userHourlyLimit,
+        dailyLimit: userDailyLimit,
+        monthlyLimit: userMonthlyLimit,
+      },
+      current: {
+        hourly: usage.hourly,
+        daily: usage.daily,
+        monthly: usage.monthly,
+      },
+      remaining: {
+        hourly: Math.max(0, userHourlyLimit - usage.hourly),
+        daily: Math.max(0, userDailyLimit - usage.daily),
+        monthly: Math.max(0, userMonthlyLimit - usage.monthly),
+      },
+      resetAt: {
+        hourly: usage.hourlyResetAt,
+        daily: usage.dailyResetAt,
+        monthly: usage.monthlyResetAt,
+      },
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Read helpers
+  // -------------------------------------------------------------------------
+
+  getUsage(apiKey: string): ApiKeyUsage | undefined {
+    const usage = this.usages.get(apiKey);
+    if (usage) this.resetIfExpired(usage);
+    return usage;
+  }
+
+  getRateLimitStatus(
+    apiKey: string,
+    tier: SubscriptionTier,
+  ): {
+    limits: TierRateLimit;
+    current: { hourly: number; daily: number; monthly: number; burstTokens: number };
+    remaining: { hourly: number; daily: number; monthly: number; burstTokens: number };
+    resetAt: { hourly: number; daily: number; monthly: number };
+  } {
+    const usage = this.getOrCreateUsage(apiKey, tier);
+    this.resetIfExpired(usage);
+    const limits = this.getEffectiveLimits(apiKey, tier);
+
+    return {
+      limits,
+      current: {
+        hourly: usage.hourly,
+        daily: usage.daily,
+        monthly: usage.monthly,
+        burstTokens: usage.burstTokens,
+      },
+      remaining: {
+        hourly: Math.max(0, limits.hourlyLimit - usage.hourly),
+        daily: Math.max(0, limits.dailyLimit - usage.daily),
+        monthly: Math.max(0, limits.monthlyLimit - usage.monthly),
+        burstTokens: Math.max(0, usage.burstTokens),
+      },
+      resetAt: {
+        hourly: usage.hourlyResetAt,
+        daily: usage.dailyResetAt,
+        monthly: usage.monthlyResetAt,
+      },
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Analytics
+  // -------------------------------------------------------------------------
 
   getAnalytics(tier?: SubscriptionTier): UsageAnalytics {
     let entries = this.requestLog;
@@ -201,6 +464,20 @@ export class RateLimitingService {
       .slice(0, 10)
       .map(([endpoint, count]) => ({ endpoint, count }));
 
+    // Hourly breakdown over the last 24 h
+    const hourlyBuckets = new Map<string, number>();
+    const nowTs = now();
+    for (const entry of entries) {
+      const age = nowTs - entry.timestamp;
+      if (age > ONE_DAY_MS) continue;
+      const hourOffset = Math.floor(age / ONE_HOUR_MS);
+      const hourLabel = `${23 - hourOffset}h ago`;
+      hourlyBuckets.set(hourLabel, (hourlyBuckets.get(hourLabel) ?? 0) + 1);
+    }
+    const hourlyBreakdown = Array.from(hourlyBuckets.entries())
+      .map(([hour, count]) => ({ hour, count }))
+      .sort((a, b) => a.hour.localeCompare(b.hour));
+
     return {
       totalRequests,
       requestsByTier,
@@ -211,9 +488,73 @@ export class RateLimitingService {
       errorRate: totalRequests > 0 ? errorCount / totalRequests : 0,
       rateLimitHitCount: rateLimitHits,
       topEndpoints,
-      hourlyBreakdown: [],
+      hourlyBreakdown,
     };
   }
+
+  /**
+   * Returns analytics specifically for rate-limit events.
+   */
+  getRateLimitAnalytics(): {
+    totalRequests: number;
+    rateLimitHits: number;
+    hitRate: number;
+    topThrottledKeys: { key: string; hits: number }[];
+    topThrottledEndpoints: { endpoint: string; hits: number }[];
+    byTier: Record<SubscriptionTier, { requests: number; hits: number; hitRate: number }>;
+  } {
+    const byKey = new Map<string, number>();
+    const byEndpoint = new Map<string, number>();
+    const byTier: Record<
+      SubscriptionTier,
+      { requests: number; hits: number; hitRate: number }
+    > = {
+      [SubscriptionTier.FREE]: { requests: 0, hits: 0, hitRate: 0 },
+      [SubscriptionTier.BASIC]: { requests: 0, hits: 0, hitRate: 0 },
+      [SubscriptionTier.PREMIUM]: { requests: 0, hits: 0, hitRate: 0 },
+      [SubscriptionTier.ENTERPRISE]: { requests: 0, hits: 0, hitRate: 0 },
+    };
+
+    let rateLimitHits = 0;
+
+    for (const entry of this.requestLog) {
+      byTier[entry.tier].requests += 1;
+      if (entry.statusCode === 429) {
+        rateLimitHits += 1;
+        byKey.set(entry.apiKey, (byKey.get(entry.apiKey) ?? 0) + 1);
+        byEndpoint.set(entry.endpoint, (byEndpoint.get(entry.endpoint) ?? 0) + 1);
+        byTier[entry.tier].hits += 1;
+      }
+    }
+
+    for (const t of Object.values(SubscriptionTier)) {
+      const b = byTier[t as SubscriptionTier];
+      b.hitRate = b.requests > 0 ? b.hits / b.requests : 0;
+    }
+
+    const topThrottledKeys = Array.from(byKey.entries())
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 10)
+      .map(([key, hits]) => ({ key, hits }));
+
+    const topThrottledEndpoints = Array.from(byEndpoint.entries())
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 10)
+      .map(([endpoint, hits]) => ({ endpoint, hits }));
+
+    return {
+      totalRequests: this.requestLog.length,
+      rateLimitHits,
+      hitRate: this.requestLog.length > 0 ? rateLimitHits / this.requestLog.length : 0,
+      topThrottledKeys,
+      topThrottledEndpoints,
+      byTier,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Tier upgrade recommendation
+  // -------------------------------------------------------------------------
 
   checkTierUpgrade(apiKey: string): TierUpgradeRecommendation | null {
     const usage = this.usages.get(apiKey);
@@ -223,7 +564,7 @@ export class RateLimitingService {
     const nextTier = getNextTier(usage.tier);
     if (!nextTier) return null;
 
-    const limits = TIER_RATE_LIMITS[usage.tier];
+    const limits = this.getEffectiveLimits(apiKey, usage.tier);
     const threshold = TIER_UPGRADE_THRESHOLDS[usage.tier];
     const hourlyUsagePct = usage.hourly / limits.hourlyLimit;
 
@@ -242,37 +583,9 @@ export class RateLimitingService {
     return null;
   }
 
-  getRateLimitStatus(apiKey: string, tier: SubscriptionTier): {
-    limits: TierRateLimit;
-    current: { hourly: number; daily: number; monthly: number; burstTokens: number };
-    remaining: { hourly: number; daily: number; monthly: number; burstTokens: number };
-    resetAt: { hourly: number; daily: number; monthly: number };
-  } {
-    const usage = this.getOrCreateUsage(apiKey, tier);
-    this.resetIfExpired(usage);
-    const limits = TIER_RATE_LIMITS[tier];
-
-    return {
-      limits,
-      current: {
-        hourly: usage.hourly,
-        daily: usage.daily,
-        monthly: usage.monthly,
-        burstTokens: usage.burstTokens,
-      },
-      remaining: {
-        hourly: Math.max(0, limits.hourlyLimit - usage.hourly),
-        daily: Math.max(0, limits.dailyLimit - usage.daily),
-        monthly: Math.max(0, limits.monthlyLimit - usage.monthly),
-        burstTokens: Math.max(0, usage.burstTokens),
-      },
-      resetAt: {
-        hourly: usage.hourlyResetAt,
-        daily: usage.dailyResetAt,
-        monthly: usage.monthlyResetAt,
-      },
-    };
-  }
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
 
   private resetIfExpired(usage: ApiKeyUsage): void {
     const now_ts = now();

--- a/developer-portal/src/components/RateLimitConfigPanel.tsx
+++ b/developer-portal/src/components/RateLimitConfigPanel.tsx
@@ -1,0 +1,697 @@
+/**
+ * RateLimitConfigPanel — developer portal component for configuring per-key
+ * and per-user rate limits.
+ *
+ * Features:
+ *   - View current tier limits
+ *   - Set custom hourly / daily / monthly / burst / concurrent limits per key
+ *   - Manage bypass list (trusted keys and user IDs)
+ *   - Live status display (remaining quota)
+ *   - Accessibility: all interactive elements have aria labels and are keyboard navigable
+ */
+
+import React, { useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+  ScrollView,
+  Switch,
+  Alert,
+  ActivityIndicator,
+} from 'react-native';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface KeyRateLimitConfig {
+  apiKey: string;
+  hourlyLimit?: number;
+  dailyLimit?: number;
+  monthlyLimit?: number;
+  burstLimit?: number;
+  concurrentLimit?: number;
+}
+
+export interface BypassEntry {
+  type: 'key' | 'user';
+  value: string;
+}
+
+export interface RateLimitStatus {
+  limits: {
+    hourlyLimit: number;
+    dailyLimit: number;
+    monthlyLimit: number;
+    burstLimit: number;
+    concurrentLimit: number;
+  };
+  current: {
+    hourly: number;
+    daily: number;
+    monthly: number;
+    burstTokens: number;
+  };
+  remaining: {
+    hourly: number;
+    daily: number;
+    monthly: number;
+    burstTokens: number;
+  };
+  resetAt: {
+    hourly: number;
+    daily: number;
+    monthly: number;
+  };
+}
+
+export interface RateLimitConfigPanelProps {
+  /** The API key whose limits are being configured. */
+  apiKey: string;
+  /** Current rate-limit status for the key (from the API). */
+  status?: RateLimitStatus | null;
+  /** Bypass entries currently in the service. */
+  bypassEntries?: BypassEntry[];
+  /** Whether the key is currently bypassed. */
+  isBypassed?: boolean;
+  /** Called when the user saves a custom config. */
+  onSaveConfig: (config: KeyRateLimitConfig) => Promise<void>;
+  /** Called to add or remove a bypass entry. */
+  onBypassChange: (entry: BypassEntry, action: 'add' | 'remove') => Promise<void>;
+  /** Called to toggle bypass for this specific key. */
+  onToggleBypass?: (apiKey: string, bypass: boolean) => Promise<void>;
+  /** Whether the panel is in a loading state. */
+  loading?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+function parseOptInt(s: string): number | undefined {
+  const n = parseInt(s, 10);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+function formatReset(ts: number): string {
+  const diff = ts - Date.now();
+  if (diff <= 0) return 'now';
+  const mins = Math.ceil(diff / 60_000);
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.ceil(diff / 3_600_000);
+  return `${hrs}h`;
+}
+
+function UsageBar({ current, limit, label }: { current: number; limit: number; label: string }) {
+  const pct = Math.min(100, limit > 0 ? (current / limit) * 100 : 0);
+  const color = pct >= 90 ? '#EF4444' : pct >= 75 ? '#F59E0B' : '#22C55E';
+  return (
+    <View
+      style={barStyles.wrapper}
+      accessibilityRole="progressbar"
+      accessibilityLabel={label}
+      accessibilityValue={{ min: 0, max: 100, now: Math.round(pct) }}>
+      <View style={barStyles.row}>
+        <Text style={barStyles.label}>{label}</Text>
+        <Text style={barStyles.counts}>
+          {current.toLocaleString()} / {limit.toLocaleString()}
+        </Text>
+      </View>
+      <View style={barStyles.track}>
+        <View style={[barStyles.fill, { width: `${pct}%`, backgroundColor: color }]} />
+      </View>
+      <Text style={barStyles.pct}>{pct.toFixed(1)}%</Text>
+    </View>
+  );
+}
+
+const barStyles = StyleSheet.create({
+  wrapper: { marginBottom: 12 },
+  row: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 4 },
+  label: { fontSize: 13, color: '#374151', fontWeight: '500' },
+  counts: { fontSize: 13, color: '#6B7280' },
+  track: { height: 8, backgroundColor: '#E5E7EB', borderRadius: 4, overflow: 'hidden' },
+  fill: { height: '100%', borderRadius: 4 },
+  pct: { fontSize: 11, color: '#9CA3AF', marginTop: 2 },
+});
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export const RateLimitConfigPanel: React.FC<RateLimitConfigPanelProps> = ({
+  apiKey,
+  status,
+  bypassEntries = [],
+  isBypassed = false,
+  onSaveConfig,
+  onBypassChange,
+  onToggleBypass,
+  loading = false,
+}) => {
+  const [hourly, setHourly] = useState('');
+  const [daily, setDaily] = useState('');
+  const [monthly, setMonthly] = useState('');
+  const [burst, setBurst] = useState('');
+  const [concurrent, setConcurrent] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const [bypassType, setBypassType] = useState<'key' | 'user'>('key');
+  const [bypassValue, setBypassValue] = useState('');
+  const [bypassLoading, setBypassLoading] = useState(false);
+
+  const handleSave = useCallback(async () => {
+    const config: KeyRateLimitConfig = {
+      apiKey,
+      hourlyLimit: parseOptInt(hourly),
+      dailyLimit: parseOptInt(daily),
+      monthlyLimit: parseOptInt(monthly),
+      burstLimit: parseOptInt(burst),
+      concurrentLimit: parseOptInt(concurrent),
+    };
+
+    // Validate: daily must be ≥ hourly if both specified
+    if (config.hourlyLimit && config.dailyLimit && config.dailyLimit < config.hourlyLimit) {
+      Alert.alert('Validation Error', 'Daily limit must be greater than or equal to hourly limit.');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      await onSaveConfig(config);
+      Alert.alert('Saved', 'Rate limit configuration updated successfully.');
+    } catch {
+      Alert.alert('Error', 'Failed to save rate limit configuration.');
+    } finally {
+      setSaving(false);
+    }
+  }, [apiKey, hourly, daily, monthly, burst, concurrent, onSaveConfig]);
+
+  const handleAddBypass = useCallback(async () => {
+    if (!bypassValue.trim()) {
+      Alert.alert('Validation Error', 'Please enter a key or user ID to bypass.');
+      return;
+    }
+    setBypassLoading(true);
+    try {
+      await onBypassChange({ type: bypassType, value: bypassValue.trim() }, 'add');
+      setBypassValue('');
+    } catch {
+      Alert.alert('Error', 'Failed to add bypass entry.');
+    } finally {
+      setBypassLoading(false);
+    }
+  }, [bypassType, bypassValue, onBypassChange]);
+
+  const handleRemoveBypass = useCallback(
+    async (entry: BypassEntry) => {
+      setBypassLoading(true);
+      try {
+        await onBypassChange(entry, 'remove');
+      } catch {
+        Alert.alert('Error', 'Failed to remove bypass entry.');
+      } finally {
+        setBypassLoading(false);
+      }
+    },
+    [onBypassChange]
+  );
+
+  if (loading) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator size="large" color="#3B82F6" />
+        <Text style={styles.loadingText}>Loading rate limit configuration…</Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView style={styles.container} showsVerticalScrollIndicator={false}>
+      {/* ------------------------------------------------------------------ */}
+      {/* Live Status                                                          */}
+      {/* ------------------------------------------------------------------ */}
+      {status && (
+        <View style={styles.card} accessibilityLabel="Current rate limit usage">
+          <Text style={styles.cardTitle}>Current Usage</Text>
+          <UsageBar
+            label="Hourly"
+            current={status.current.hourly}
+            limit={status.limits.hourlyLimit}
+          />
+          <UsageBar label="Daily" current={status.current.daily} limit={status.limits.dailyLimit} />
+          <UsageBar
+            label="Monthly"
+            current={status.current.monthly}
+            limit={status.limits.monthlyLimit}
+          />
+          <UsageBar
+            label="Burst tokens"
+            current={status.limits.burstLimit - status.current.burstTokens}
+            limit={status.limits.burstLimit}
+          />
+
+          <View style={styles.resetRow}>
+            <Text style={styles.resetLabel}>Hourly reset:</Text>
+            <Text style={styles.resetValue}>{formatReset(status.resetAt.hourly)}</Text>
+            <Text style={styles.resetLabel}>Daily reset:</Text>
+            <Text style={styles.resetValue}>{formatReset(status.resetAt.daily)}</Text>
+            <Text style={styles.resetLabel}>Monthly reset:</Text>
+            <Text style={styles.resetValue}>{formatReset(status.resetAt.monthly)}</Text>
+          </View>
+        </View>
+      )}
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Bypass toggle for this key                                           */}
+      {/* ------------------------------------------------------------------ */}
+      {onToggleBypass && (
+        <View style={styles.card}>
+          <View style={styles.toggleRow}>
+            <View style={styles.toggleTextWrap}>
+              <Text style={styles.toggleLabel}>Bypass Rate Limiting</Text>
+              <Text style={styles.toggleHint}>
+                Trusted service accounts can skip all rate checks.
+              </Text>
+            </View>
+            <Switch
+              value={isBypassed}
+              onValueChange={(v) => onToggleBypass(apiKey, v)}
+              trackColor={{ false: '#D1D5DB', true: '#3B82F6' }}
+              thumbColor="#FFFFFF"
+              accessibilityLabel="Toggle rate limit bypass for this key"
+            />
+          </View>
+          {isBypassed && (
+            <View style={styles.warningBanner}>
+              <Text style={styles.warningText}>
+                ⚠️ This key bypasses all rate limits. Use only for trusted internal services.
+              </Text>
+            </View>
+          )}
+        </View>
+      )}
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Custom Limits                                                        */}
+      {/* ------------------------------------------------------------------ */}
+      <View style={styles.card}>
+        <Text style={styles.cardTitle}>Custom Limits</Text>
+        <Text style={styles.cardSubtitle}>
+          Override the tier defaults for this specific API key. Leave blank to use tier defaults.
+        </Text>
+
+        {[
+          {
+            label: 'Hourly limit',
+            value: hourly,
+            setter: setHourly,
+            placeholder: `e.g. ${status?.limits.hourlyLimit ?? 100}`,
+          },
+          {
+            label: 'Daily limit',
+            value: daily,
+            setter: setDaily,
+            placeholder: `e.g. ${status?.limits.dailyLimit ?? 2400}`,
+          },
+          {
+            label: 'Monthly limit',
+            value: monthly,
+            setter: setMonthly,
+            placeholder: `e.g. ${status?.limits.monthlyLimit ?? 72000}`,
+          },
+          {
+            label: 'Burst limit',
+            value: burst,
+            setter: setBurst,
+            placeholder: `e.g. ${status?.limits.burstLimit ?? 20}`,
+          },
+          {
+            label: 'Concurrent limit',
+            value: concurrent,
+            setter: setConcurrent,
+            placeholder: `e.g. ${status?.limits.concurrentLimit ?? 5}`,
+          },
+        ].map(({ label, value, setter, placeholder }) => (
+          <View key={label} style={styles.inputGroup}>
+            <Text style={styles.inputLabel}>{label}</Text>
+            <TextInput
+              style={styles.input}
+              value={value}
+              onChangeText={setter}
+              keyboardType="number-pad"
+              placeholder={placeholder}
+              placeholderTextColor="#9CA3AF"
+              accessibilityLabel={label}
+            />
+          </View>
+        ))}
+
+        <TouchableOpacity
+          style={[styles.button, saving && styles.buttonDisabled]}
+          onPress={handleSave}
+          disabled={saving}
+          accessibilityRole="button"
+          accessibilityLabel="Save custom rate limit configuration">
+          {saving ? (
+            <ActivityIndicator size="small" color="#FFFFFF" />
+          ) : (
+            <Text style={styles.buttonText}>Save Configuration</Text>
+          )}
+        </TouchableOpacity>
+      </View>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Bypass List Management                                               */}
+      {/* ------------------------------------------------------------------ */}
+      <View style={styles.card}>
+        <Text style={styles.cardTitle}>Bypass List</Text>
+        <Text style={styles.cardSubtitle}>
+          Keys and user IDs in this list skip rate limiting entirely.
+        </Text>
+
+        {/* Type selector */}
+        <View style={styles.typeSelector}>
+          {(['key', 'user'] as const).map((t) => (
+            <TouchableOpacity
+              key={t}
+              style={[styles.typeBtn, bypassType === t && styles.typeBtnActive]}
+              onPress={() => setBypassType(t)}
+              accessibilityRole="radio"
+              accessibilityState={{ selected: bypassType === t }}
+              accessibilityLabel={`Bypass type: ${t === 'key' ? 'API key' : 'User ID'}`}>
+              <Text style={[styles.typeBtnText, bypassType === t && styles.typeBtnTextActive]}>
+                {t === 'key' ? 'API Key' : 'User ID'}
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+
+        <View style={styles.addBypassRow}>
+          <TextInput
+            style={[styles.input, styles.bypassInput]}
+            value={bypassValue}
+            onChangeText={setBypassValue}
+            placeholder={bypassType === 'key' ? 'Enter API key…' : 'Enter user ID…'}
+            placeholderTextColor="#9CA3AF"
+            accessibilityLabel={`${bypassType === 'key' ? 'API key' : 'User ID'} to add to bypass list`}
+          />
+          <TouchableOpacity
+            style={[styles.addBtn, bypassLoading && styles.buttonDisabled]}
+            onPress={handleAddBypass}
+            disabled={bypassLoading}
+            accessibilityRole="button"
+            accessibilityLabel="Add to bypass list">
+            {bypassLoading ? (
+              <ActivityIndicator size="small" color="#FFFFFF" />
+            ) : (
+              <Text style={styles.addBtnText}>Add</Text>
+            )}
+          </TouchableOpacity>
+        </View>
+
+        {/* Existing bypass entries */}
+        {bypassEntries.length === 0 ? (
+          <Text style={styles.emptyText}>No bypass entries configured.</Text>
+        ) : (
+          bypassEntries.map((entry, idx) => (
+            <View key={`${entry.type}-${entry.value}-${idx}`} style={styles.bypassItem}>
+              <View style={styles.bypassBadge}>
+                <Text style={styles.bypassBadgeText}>{entry.type === 'key' ? 'KEY' : 'USER'}</Text>
+              </View>
+              <Text style={styles.bypassValue} numberOfLines={1}>
+                {entry.value}
+              </Text>
+              <TouchableOpacity
+                onPress={() => handleRemoveBypass(entry)}
+                accessibilityRole="button"
+                accessibilityLabel={`Remove ${entry.value} from bypass list`}
+                style={styles.removeBtn}>
+                <Text style={styles.removeBtnText}>Remove</Text>
+              </TouchableOpacity>
+            </View>
+          ))
+        )}
+      </View>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Info: what do these limits mean                                      */}
+      {/* ------------------------------------------------------------------ */}
+      <View style={[styles.card, styles.infoCard]}>
+        <Text style={styles.infoTitle}>ℹ️ About Rate Limits</Text>
+        <Text style={styles.infoText}>
+          <Text style={styles.bold}>Hourly limit:</Text> Maximum requests in a rolling 60-minute
+          window.{'\n'}
+          <Text style={styles.bold}>Daily limit:</Text> Maximum requests in a rolling 24-hour
+          window.{'\n'}
+          <Text style={styles.bold}>Monthly limit:</Text> Maximum requests in a rolling 30-day
+          window.{'\n'}
+          <Text style={styles.bold}>Burst limit:</Text> Token bucket size for short-lived request
+          spikes.{'\n'}
+          <Text style={styles.bold}>Concurrent limit:</Text> Max simultaneous in-flight requests.
+          {'\n\n'}
+          Per-user limits aggregate across all API keys owned by the same user account and are set
+          to 5× the per-key hourly limit.
+        </Text>
+      </View>
+    </ScrollView>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F9FAFB',
+    padding: 16,
+  },
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 32,
+  },
+  loadingText: {
+    marginTop: 12,
+    fontSize: 14,
+    color: '#6B7280',
+  },
+  card: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 16,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  cardTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#111827',
+    marginBottom: 4,
+  },
+  cardSubtitle: {
+    fontSize: 13,
+    color: '#6B7280',
+    marginBottom: 16,
+    lineHeight: 18,
+  },
+  inputGroup: {
+    marginBottom: 12,
+  },
+  inputLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#374151',
+    marginBottom: 6,
+  },
+  input: {
+    backgroundColor: '#F9FAFB',
+    borderWidth: 1,
+    borderColor: '#D1D5DB',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 14,
+    color: '#111827',
+  },
+  button: {
+    backgroundColor: '#3B82F6',
+    borderRadius: 8,
+    paddingVertical: 12,
+    alignItems: 'center',
+    marginTop: 4,
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+  buttonText: {
+    color: '#FFFFFF',
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  resetRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginTop: 8,
+    gap: 8,
+  },
+  resetLabel: {
+    fontSize: 12,
+    color: '#6B7280',
+  },
+  resetValue: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#111827',
+    marginRight: 8,
+  },
+  toggleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  toggleTextWrap: {
+    flex: 1,
+    marginRight: 12,
+  },
+  toggleLabel: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#111827',
+  },
+  toggleHint: {
+    fontSize: 12,
+    color: '#6B7280',
+    marginTop: 2,
+  },
+  warningBanner: {
+    backgroundColor: '#FEF3C7',
+    borderRadius: 8,
+    padding: 10,
+    marginTop: 12,
+  },
+  warningText: {
+    fontSize: 13,
+    color: '#92400E',
+  },
+  typeSelector: {
+    flexDirection: 'row',
+    marginBottom: 12,
+    backgroundColor: '#F3F4F6',
+    borderRadius: 8,
+    padding: 4,
+  },
+  typeBtn: {
+    flex: 1,
+    paddingVertical: 8,
+    alignItems: 'center',
+    borderRadius: 6,
+  },
+  typeBtnActive: {
+    backgroundColor: '#FFFFFF',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.08,
+    shadowRadius: 2,
+    elevation: 1,
+  },
+  typeBtnText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#6B7280',
+  },
+  typeBtnTextActive: {
+    color: '#3B82F6',
+  },
+  addBypassRow: {
+    flexDirection: 'row',
+    gap: 8,
+    marginBottom: 12,
+  },
+  bypassInput: {
+    flex: 1,
+  },
+  addBtn: {
+    backgroundColor: '#3B82F6',
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  addBtnText: {
+    color: '#FFFFFF',
+    fontWeight: '600',
+    fontSize: 14,
+  },
+  bypassItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#F9FAFB',
+    borderRadius: 8,
+    padding: 10,
+    marginBottom: 8,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  bypassBadge: {
+    backgroundColor: '#EFF6FF',
+    borderRadius: 4,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    marginRight: 8,
+  },
+  bypassBadgeText: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: '#1D4ED8',
+    letterSpacing: 0.5,
+  },
+  bypassValue: {
+    flex: 1,
+    fontSize: 13,
+    color: '#374151',
+    fontFamily: 'monospace',
+  },
+  removeBtn: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+  },
+  removeBtnText: {
+    color: '#EF4444',
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  emptyText: {
+    fontSize: 13,
+    color: '#9CA3AF',
+    textAlign: 'center',
+    paddingVertical: 8,
+  },
+  infoCard: {
+    backgroundColor: '#EFF6FF',
+    borderColor: '#BFDBFE',
+  },
+  infoTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#1D4ED8',
+    marginBottom: 8,
+  },
+  infoText: {
+    fontSize: 13,
+    color: '#1E40AF',
+    lineHeight: 20,
+  },
+  bold: {
+    fontWeight: '700',
+  },
+});
+
+export default RateLimitConfigPanel;

--- a/developer-portal/src/screens/RateLimitAnalyticsDashboard.tsx
+++ b/developer-portal/src/screens/RateLimitAnalyticsDashboard.tsx
@@ -1,0 +1,641 @@
+/**
+ * RateLimitAnalyticsDashboard — developer portal screen displaying rate-limit
+ * analytics: hit rate, throttled keys, per-tier breakdown, and hourly trends.
+ *
+ * Accessibility compliant (WCAG 2.1 AA):
+ *   - All progress indicators have accessibilityRole="progressbar"
+ *   - Colour is not the sole indicator of state (text labels added)
+ *   - Keyboard navigable (all interactive elements are TouchableOpacity)
+ */
+
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  RefreshControl,
+  ActivityIndicator,
+  AccessibilityInfo,
+} from 'react-native';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface TierBreakdown {
+  requests: number;
+  hits: number;
+  hitRate: number;
+}
+
+interface ThrottledEntry {
+  key: string;
+  hits: number;
+}
+
+export interface RateLimitAnalyticsData {
+  totalRequests: number;
+  rateLimitHits: number;
+  hitRate: number;
+  topThrottledKeys: ThrottledEntry[];
+  topThrottledEndpoints: ThrottledEntry[];
+  byTier: Record<string, TierBreakdown>;
+}
+
+export interface HourlyDataPoint {
+  hour: string;
+  requests: number;
+  hits: number;
+}
+
+export interface RateLimitAnalyticsDashboardProps {
+  /** Fetch analytics from the API. */
+  onFetchAnalytics: () => Promise<RateLimitAnalyticsData>;
+  /** Optional hourly trend data. */
+  hourlyData?: HourlyDataPoint[];
+  /** Optional period selector (default: '24h'). */
+  defaultPeriod?: '24h' | '7d' | '30d';
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function StatCard({
+  label,
+  value,
+  sub,
+  accent,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  accent?: string;
+}) {
+  return (
+    <View
+      style={statStyles.card}
+      accessibilityRole="summary"
+      accessibilityLabel={`${label}: ${value}${sub ? `, ${sub}` : ''}`}>
+      <Text style={[statStyles.value, accent ? { color: accent } : {}]}>{value}</Text>
+      <Text style={statStyles.label}>{label}</Text>
+      {sub && <Text style={statStyles.sub}>{sub}</Text>}
+    </View>
+  );
+}
+
+const statStyles = StyleSheet.create({
+  card: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    padding: 16,
+    flex: 1,
+    minWidth: '45%',
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  value: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: '#111827',
+    marginBottom: 4,
+  },
+  label: {
+    fontSize: 13,
+    color: '#6B7280',
+  },
+  sub: {
+    fontSize: 11,
+    color: '#9CA3AF',
+    marginTop: 2,
+  },
+});
+
+function TierRow({ tier, data }: { tier: string; data: TierBreakdown }) {
+  const pct = Math.min(100, Math.round(data.hitRate * 100));
+  const color = pct >= 20 ? '#EF4444' : pct >= 5 ? '#F59E0B' : '#22C55E';
+  const label = pct >= 20 ? 'High' : pct >= 5 ? 'Medium' : 'Low';
+
+  return (
+    <View style={tierStyles.row} accessibilityRole="listitem">
+      <View style={tierStyles.left}>
+        <Text style={tierStyles.tier}>{tier}</Text>
+        <Text style={tierStyles.reqs}>{data.requests.toLocaleString()} requests</Text>
+      </View>
+      <View style={tierStyles.right}>
+        <View style={tierStyles.badgeRow}>
+          <View style={[tierStyles.badge, { backgroundColor: `${color}20`, borderColor: color }]}>
+            <Text style={[tierStyles.badgeText, { color }]}>{label}</Text>
+          </View>
+          <Text style={tierStyles.pct}>{pct}% throttled</Text>
+        </View>
+        <View
+          style={tierStyles.track}
+          accessibilityRole="progressbar"
+          accessibilityValue={{ min: 0, max: 100, now: pct }}
+          accessibilityLabel={`${tier} throttle rate ${pct}%`}>
+          <View style={[tierStyles.fill, { width: `${pct}%`, backgroundColor: color }]} />
+        </View>
+        <Text style={tierStyles.hits}>{data.hits.toLocaleString()} hits</Text>
+      </View>
+    </View>
+  );
+}
+
+const tierStyles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: '#F3F4F6',
+    alignItems: 'flex-start',
+  },
+  left: { flex: 1, paddingRight: 8 },
+  tier: { fontSize: 14, fontWeight: '600', color: '#111827', textTransform: 'capitalize' },
+  reqs: { fontSize: 12, color: '#6B7280', marginTop: 2 },
+  right: { flex: 1, alignItems: 'flex-end' },
+  badgeRow: { flexDirection: 'row', alignItems: 'center', gap: 6, marginBottom: 4 },
+  badge: {
+    borderWidth: 1,
+    borderRadius: 4,
+    paddingHorizontal: 6,
+    paddingVertical: 1,
+  },
+  badgeText: { fontSize: 10, fontWeight: '700', letterSpacing: 0.3 },
+  pct: { fontSize: 12, color: '#374151' },
+  track: {
+    width: '100%',
+    height: 6,
+    backgroundColor: '#E5E7EB',
+    borderRadius: 3,
+    overflow: 'hidden',
+    marginBottom: 2,
+  },
+  fill: { height: '100%', borderRadius: 3 },
+  hits: { fontSize: 11, color: '#9CA3AF' },
+});
+
+function ThrottledList({ title, entries }: { title: string; entries: ThrottledEntry[] }) {
+  if (entries.length === 0) {
+    return (
+      <View style={listStyles.empty}>
+        <Text style={listStyles.emptyText}>No throttled {title.toLowerCase()} in this period.</Text>
+      </View>
+    );
+  }
+  const max = entries[0]?.hits ?? 1;
+  return (
+    <View accessibilityRole="list" accessibilityLabel={title}>
+      {entries.map((e, i) => {
+        const pct = Math.round((e.hits / max) * 100);
+        return (
+          <View key={e.key} style={listStyles.row} accessibilityRole="listitem">
+            <Text style={listStyles.rank} accessibilityElementsHidden>
+              #{i + 1}
+            </Text>
+            <View style={listStyles.middle}>
+              <Text style={listStyles.key} numberOfLines={1}>
+                {e.key}
+              </Text>
+              <View
+                style={listStyles.track}
+                accessibilityRole="progressbar"
+                accessibilityValue={{ min: 0, max: 100, now: pct }}>
+                <View style={[listStyles.fill, { width: `${pct}%` }]} />
+              </View>
+            </View>
+            <Text style={listStyles.hits}>{e.hits.toLocaleString()}</Text>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+const listStyles = StyleSheet.create({
+  empty: { paddingVertical: 12 },
+  emptyText: { fontSize: 13, color: '#9CA3AF', textAlign: 'center' },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: '#F3F4F6',
+  },
+  rank: { width: 28, fontSize: 12, color: '#9CA3AF', fontWeight: '600' },
+  middle: { flex: 1, marginHorizontal: 8 },
+  key: { fontSize: 12, color: '#374151', fontFamily: 'monospace', marginBottom: 4 },
+  track: { height: 4, backgroundColor: '#E5E7EB', borderRadius: 2, overflow: 'hidden' },
+  fill: { height: '100%', backgroundColor: '#EF4444', borderRadius: 2 },
+  hits: { width: 48, fontSize: 12, fontWeight: '600', color: '#111827', textAlign: 'right' },
+});
+
+function TrendChart({ data }: { data: HourlyDataPoint[] }) {
+  const maxReqs = Math.max(...data.map((d) => d.requests), 1);
+  return (
+    <View
+      style={chartStyles.container}
+      accessibilityRole="image"
+      accessibilityLabel="Hourly request and throttle trend chart">
+      {data.map((d, i) => {
+        const reqH = Math.max(4, (d.requests / maxReqs) * 100);
+        const hitH = Math.max(0, (d.hits / maxReqs) * 100);
+        return (
+          <View key={i} style={chartStyles.col}>
+            <View style={chartStyles.barWrap}>
+              <View style={[chartStyles.barReq, { height: reqH }]} />
+              {d.hits > 0 && <View style={[chartStyles.barHit, { height: hitH }]} />}
+            </View>
+            {i % 4 === 0 && <Text style={chartStyles.label}>{d.hour}</Text>}
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+const chartStyles = StyleSheet.create({
+  container: { flexDirection: 'row', alignItems: 'flex-end', height: 120, marginTop: 8 },
+  col: { flex: 1, alignItems: 'center' },
+  barWrap: { height: 100, justifyContent: 'flex-end', width: '80%', position: 'relative' },
+  barReq: { backgroundColor: '#BFDBFE', borderRadius: 2, width: '100%' },
+  barHit: {
+    backgroundColor: '#EF4444',
+    borderRadius: 2,
+    width: '100%',
+    position: 'absolute',
+    bottom: 0,
+  },
+  label: { fontSize: 9, color: '#9CA3AF', marginTop: 4 },
+});
+
+// ---------------------------------------------------------------------------
+// Main screen
+// ---------------------------------------------------------------------------
+
+const PERIODS = ['24h', '7d', '30d'] as const;
+type Period = (typeof PERIODS)[number];
+
+export const RateLimitAnalyticsDashboard: React.FC<RateLimitAnalyticsDashboardProps> = ({
+  onFetchAnalytics,
+  hourlyData = [],
+  defaultPeriod = '24h',
+}) => {
+  const [period, setPeriod] = useState<Period>(defaultPeriod);
+  const [analytics, setAnalytics] = useState<RateLimitAnalyticsData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<'keys' | 'endpoints'>('keys');
+
+  const load = useCallback(
+    async (silent = false) => {
+      if (!silent) setLoading(true);
+      setError(null);
+      try {
+        const data = await onFetchAnalytics();
+        setAnalytics(data);
+        AccessibilityInfo.announceForAccessibility('Rate limit analytics updated.');
+      } catch {
+        setError('Failed to load rate limit analytics. Please try again.');
+      } finally {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    },
+    [onFetchAnalytics]
+  );
+
+  useEffect(() => {
+    void load();
+  }, [period, load]);
+
+  const onRefresh = useCallback(() => {
+    setRefreshing(true);
+    void load(true);
+  }, [load]);
+
+  if (loading && !analytics) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator size="large" color="#3B82F6" />
+        <Text style={styles.loadingText}>Loading analytics…</Text>
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.errorText}>{error}</Text>
+        <TouchableOpacity
+          style={styles.retryBtn}
+          onPress={() => void load()}
+          accessibilityRole="button">
+          <Text style={styles.retryBtnText}>Retry</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  const a = analytics!;
+  const hitPct = ((a.hitRate ?? 0) * 100).toFixed(1);
+
+  const tierOrder = ['FREE', 'BASIC', 'PREMIUM', 'ENTERPRISE'];
+  const sortedTiers = Object.entries(a.byTier).sort(
+    ([a], [b]) => tierOrder.indexOf(a) - tierOrder.indexOf(b)
+  );
+
+  return (
+    <ScrollView
+      style={styles.container}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+      showsVerticalScrollIndicator={false}>
+      {/* Header */}
+      <View style={styles.header}>
+        <Text style={styles.title}>Rate Limit Analytics</Text>
+        <Text style={styles.subtitle}>
+          Monitor throttled requests and quota usage across your API.
+        </Text>
+      </View>
+
+      {/* Period selector */}
+      <View
+        style={styles.periodRow}
+        accessibilityRole="radiogroup"
+        accessibilityLabel="Select time period">
+        {PERIODS.map((p) => (
+          <TouchableOpacity
+            key={p}
+            style={[styles.periodBtn, period === p && styles.periodBtnActive]}
+            onPress={() => setPeriod(p)}
+            accessibilityRole="radio"
+            accessibilityState={{ selected: period === p }}
+            accessibilityLabel={`Period: ${p}`}>
+            <Text style={[styles.periodBtnText, period === p && styles.periodBtnTextActive]}>
+              {p}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      {/* Stats grid */}
+      <View style={styles.grid}>
+        <StatCard label="Total Requests" value={a.totalRequests.toLocaleString()} sub={period} />
+        <StatCard
+          label="Rate Limit Hits"
+          value={a.rateLimitHits.toLocaleString()}
+          accent={a.rateLimitHits > 0 ? '#EF4444' : undefined}
+        />
+        <StatCard
+          label="Throttle Rate"
+          value={`${hitPct}%`}
+          sub={a.rateLimitHits > 0 ? 'action needed' : 'healthy'}
+          accent={parseFloat(hitPct) >= 5 ? '#EF4444' : '#22C55E'}
+        />
+        <StatCard label="Tier Count" value={`${sortedTiers.length}`} sub="active tiers" />
+      </View>
+
+      {/* Trend chart */}
+      {hourlyData.length > 0 && (
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>Requests vs. Throttles (hourly)</Text>
+          <View style={styles.legendRow}>
+            <View style={[styles.legendDot, { backgroundColor: '#BFDBFE' }]} />
+            <Text style={styles.legendText}>Requests</Text>
+            <View style={[styles.legendDot, { backgroundColor: '#EF4444' }]} />
+            <Text style={styles.legendText}>Throttled</Text>
+          </View>
+          <TrendChart data={hourlyData} />
+        </View>
+      )}
+
+      {/* Tier breakdown */}
+      <View style={styles.card}>
+        <Text style={styles.cardTitle}>By Subscription Tier</Text>
+        <View accessibilityRole="list">
+          {sortedTiers.map(([tier, data]) => (
+            <TierRow key={tier} tier={tier} data={data} />
+          ))}
+          {sortedTiers.length === 0 && (
+            <Text style={styles.emptyText}>No tier data available.</Text>
+          )}
+        </View>
+      </View>
+
+      {/* Throttled keys / endpoints */}
+      <View style={styles.card}>
+        <Text style={styles.cardTitle}>
+          {activeTab === 'keys' ? 'Top Throttled API Keys' : 'Top Throttled Endpoints'}
+        </Text>
+
+        <View style={styles.tabRow} accessibilityRole="tablist">
+          {(['keys', 'endpoints'] as const).map((t) => (
+            <TouchableOpacity
+              key={t}
+              style={[styles.tab, activeTab === t && styles.tabActive]}
+              onPress={() => setActiveTab(t)}
+              accessibilityRole="tab"
+              accessibilityState={{ selected: activeTab === t }}
+              accessibilityLabel={`Tab: ${t === 'keys' ? 'Top throttled keys' : 'Top throttled endpoints'}`}>
+              <Text style={[styles.tabText, activeTab === t && styles.tabTextActive]}>
+                {t === 'keys' ? 'API Keys' : 'Endpoints'}
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+
+        <ThrottledList
+          title={activeTab === 'keys' ? 'keys' : 'endpoints'}
+          entries={activeTab === 'keys' ? a.topThrottledKeys : a.topThrottledEndpoints}
+        />
+      </View>
+
+      {/* Guidance */}
+      <View style={[styles.card, styles.guideCard]}>
+        <Text style={styles.guideTitle}>💡 Tips to Reduce Throttling</Text>
+        <Text style={styles.guideText}>
+          • Implement exponential back-off when you receive a 429 response.{'\n'}• Cache API
+          responses where possible to reduce request volume.{'\n'}• Use webhooks instead of polling
+          for event-driven use cases.{'\n'}• Upgrade to a higher tier if you consistently hit hourly
+          limits.{'\n'}• Add trusted service accounts to the bypass list via the Configuration
+          panel.
+        </Text>
+      </View>
+    </ScrollView>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F9FAFB',
+  },
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 32,
+  },
+  loadingText: {
+    marginTop: 12,
+    fontSize: 14,
+    color: '#6B7280',
+  },
+  errorText: {
+    fontSize: 14,
+    color: '#EF4444',
+    textAlign: 'center',
+    marginBottom: 16,
+  },
+  retryBtn: {
+    backgroundColor: '#3B82F6',
+    borderRadius: 8,
+    paddingHorizontal: 24,
+    paddingVertical: 10,
+  },
+  retryBtnText: {
+    color: '#FFFFFF',
+    fontWeight: '600',
+  },
+  header: {
+    padding: 24,
+    backgroundColor: '#FFFFFF',
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+  },
+  title: {
+    fontSize: 26,
+    fontWeight: '700',
+    color: '#111827',
+    marginBottom: 4,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: '#6B7280',
+    lineHeight: 20,
+  },
+  periodRow: {
+    flexDirection: 'row',
+    backgroundColor: '#FFFFFF',
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+    padding: 12,
+    gap: 8,
+  },
+  periodBtn: {
+    flex: 1,
+    paddingVertical: 8,
+    alignItems: 'center',
+    borderRadius: 8,
+    backgroundColor: '#F3F4F6',
+  },
+  periodBtnActive: {
+    backgroundColor: '#3B82F6',
+  },
+  periodBtnText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#6B7280',
+  },
+  periodBtnTextActive: {
+    color: '#FFFFFF',
+  },
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    padding: 16,
+    gap: 12,
+  },
+  card: {
+    backgroundColor: '#FFFFFF',
+    marginHorizontal: 16,
+    marginBottom: 16,
+    borderRadius: 12,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  cardTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#111827',
+    marginBottom: 12,
+  },
+  legendRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginBottom: 4,
+  },
+  legendDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+  },
+  legendText: {
+    fontSize: 12,
+    color: '#6B7280',
+    marginRight: 8,
+  },
+  tabRow: {
+    flexDirection: 'row',
+    backgroundColor: '#F3F4F6',
+    borderRadius: 8,
+    padding: 3,
+    marginBottom: 12,
+    gap: 4,
+  },
+  tab: {
+    flex: 1,
+    paddingVertical: 7,
+    alignItems: 'center',
+    borderRadius: 6,
+  },
+  tabActive: {
+    backgroundColor: '#FFFFFF',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.06,
+    shadowRadius: 2,
+    elevation: 1,
+  },
+  tabText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#6B7280',
+  },
+  tabTextActive: {
+    color: '#1D4ED8',
+  },
+  emptyText: {
+    fontSize: 13,
+    color: '#9CA3AF',
+    textAlign: 'center',
+    paddingVertical: 12,
+  },
+  guideCard: {
+    backgroundColor: '#F0FDF4',
+    borderColor: '#BBF7D0',
+    marginBottom: 32,
+  },
+  guideTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#166534',
+    marginBottom: 8,
+  },
+  guideText: {
+    fontSize: 13,
+    color: '#15803D',
+    lineHeight: 22,
+  },
+});
+
+export default RateLimitAnalyticsDashboard;

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -1,0 +1,433 @@
+# Rate Limiting
+
+SubTrackr's API enforces rate limits to ensure fair usage and platform stability. Every API key and user account has request quotas based on their subscription tier.
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Rate Limit Tiers](#rate-limit-tiers)
+3. [How Rate Limits Work](#how-rate-limits-work)
+4. [Response Headers](#response-headers)
+5. [Rate Limit Error Response](#rate-limit-error-response)
+6. [Per-User Limits](#per-user-limits)
+7. [Bypass for Trusted Clients](#bypass-for-trusted-clients)
+8. [Custom Limits per API Key](#custom-limits-per-api-key)
+9. [Analytics & Monitoring](#analytics--monitoring)
+10. [Best Practices](#best-practices)
+11. [API Reference](#api-reference)
+12. [FAQ](#faq)
+
+---
+
+## Overview
+
+Rate limiting protects the SubTrackr API from abusive traffic patterns while guaranteeing capacity for all users. Limits operate on three complementary windows:
+
+| Window | Description |
+|--------|-------------|
+| **Hourly** | Rolling 60-minute window |
+| **Daily** | Rolling 24-hour window |
+| **Monthly** | Rolling 30-day window |
+
+In addition, a **burst token bucket** smooths short-lived traffic spikes, and a **concurrency limit** caps simultaneous in-flight requests per key.
+
+---
+
+## Rate Limit Tiers
+
+| Tier | Hourly | Daily | Monthly | Burst | Concurrent |
+|------|-------:|------:|--------:|------:|-----------:|
+| **Free** | 100 | 500 | 10,000 | 20 | 2 |
+| **Basic** | 500 | 2,500 | 50,000 | 50 | 5 |
+| **Premium** | 1,000 | 10,000 | 200,000 | 100 | 10 |
+| **Enterprise** | 10,000 | 100,000 | 2,000,000 | 500 | 50 |
+
+> **Note:** Tier limits are defaults. Per-key custom limits and bypass overrides take precedence. See [Custom Limits per API Key](#custom-limits-per-api-key).
+
+---
+
+## How Rate Limits Work
+
+### Token bucket (burst)
+
+Each API key has a token bucket refilled at **1 token per second** up to the burst limit. A request consumes one token. If the bucket is empty the request is rejected even if the hourly window has remaining capacity.
+
+### Window counters
+
+Three independent sliding-window counters track requests per hour, per day, and per month. The most restrictive limit that has been exhausted determines the `Retry-After` value.
+
+### Concurrency
+
+A lightweight concurrency counter prevents stampedes. If an API key has `concurrentLimit` simultaneous in-flight requests, new requests are rejected until one of the active ones completes.
+
+### Request identity
+
+The rate limiter identifies requests by, in order of preference:
+
+1. `X-API-Key` header
+2. `Authorization: Bearer <token>` header
+3. `X-User-ID` header
+4. Client IP address (unauthenticated fallback)
+
+---
+
+## Response Headers
+
+Every non-bypassed API response includes the following headers:
+
+| Header | Type | Description |
+|--------|------|-------------|
+| `X-RateLimit-Limit` | integer | Hourly request limit for this API key |
+| `X-RateLimit-Remaining` | integer | Requests remaining in the current hourly window |
+| `X-RateLimit-Reset` | Unix timestamp (s) | Time when the hourly window resets |
+| `X-RateLimit-Policy` | string | Active policy, e.g. `premium;hourly=1000;daily=10000` |
+| `X-UserRateLimit-Limit` | integer | Per-user aggregate hourly limit |
+| `X-UserRateLimit-Remaining` | integer | Per-user requests remaining this hour |
+| `X-UserRateLimit-Reset` | Unix timestamp (s) | When the per-user hourly window resets |
+
+On a `429` response:
+
+| Header | Type | Description |
+|--------|------|-------------|
+| `Retry-After` | integer (seconds) | How many seconds to wait before retrying |
+
+---
+
+## Rate Limit Error Response
+
+When a limit is exceeded the API returns HTTP **429 Too Many Requests**:
+
+```json
+{
+  "status": 429,
+  "error": "rate_limit_exceeded",
+  "message": "Rate limit exceeded. Retry after 47 seconds.",
+  "retryAfter": 47,
+  "limit": 100,
+  "remaining": 0,
+  "resetAt": 1722038400000
+}
+```
+
+### Soft-limit warnings
+
+Before a key reaches its limit the service emits a soft-limit warning at **80%** and **95%** usage. These do not reject requests but are returned in the response body alongside successful responses.
+
+```json
+{
+  "warning": "soft_limit_reached",
+  "usagePercent": 82,
+  "limit": 100,
+  "current": 82,
+  "tier": "FREE",
+  "message": "API usage at 82% of hourly limit (82/100)"
+}
+```
+
+---
+
+## Per-User Limits
+
+In addition to per-key limits, SubTrackr enforces aggregate per-user limits to prevent circumventing quotas by creating many API keys. The per-user hourly limit is **5× the tier's per-key hourly limit**.
+
+| Tier | User Hourly | User Daily | User Monthly |
+|------|------------:|-----------:|-------------:|
+| Free | 500 | 2,500 | 50,000 |
+| Basic | 2,500 | 12,500 | 250,000 |
+| Premium | 5,000 | 50,000 | 1,000,000 |
+| Enterprise | 50,000 | 500,000 | 10,000,000 |
+
+Per-user counters are tracked separately from per-key counters. Both must be within limits for a request to succeed.
+
+---
+
+## Bypass for Trusted Clients
+
+Some internal service accounts (webhooks, CI jobs, monitoring agents) need to bypass rate limiting. SubTrackr provides a **bypass list** for this purpose.
+
+### Adding a bypass via the API
+
+```http
+POST /rate-limits/bypass
+Content-Type: application/json
+Authorization: Bearer <admin-token>
+
+{
+  "type": "key",
+  "value": "sk_internal_monitoring_abc123",
+  "action": "add"
+}
+```
+
+```http
+POST /rate-limits/bypass
+Content-Type: application/json
+
+{
+  "type": "user",
+  "value": "user_service_account_456",
+  "action": "add"
+}
+```
+
+### Removing a bypass
+
+```http
+POST /rate-limits/bypass
+Content-Type: application/json
+
+{
+  "type": "key",
+  "value": "sk_internal_monitoring_abc123",
+  "action": "remove"
+}
+```
+
+### Developer portal
+
+Go to **Developer Portal → API Keys → ⚙ Configure → Rate Limits → Bypass Rate Limiting** and toggle the switch.
+
+> ⚠️ Bypassed keys are fully exempt from all rate checks. Restrict bypass to keys that are provably non-abusive.
+
+---
+
+## Custom Limits per API Key
+
+You can override tier defaults on a per-key basis. This is useful for:
+- Dedicated integration keys that need higher burst capacity.
+- Test keys that should have a very low limit.
+- Sandbox keys isolated from production quotas.
+
+### Setting custom limits
+
+```http
+POST /rate-limits/config
+Content-Type: application/json
+
+{
+  "apiKey": "sk_live_abc123",
+  "limits": {
+    "hourlyLimit": 2000,
+    "dailyLimit": 20000,
+    "monthlyLimit": 400000,
+    "burstLimit": 200,
+    "concurrentLimit": 20
+  }
+}
+```
+
+Omit any field to keep the tier default for that dimension.
+
+### Developer portal
+
+Go to **Developer Portal → API Keys → ⚙ Configure → Rate Limits → Custom Limits**.
+
+---
+
+## Analytics & Monitoring
+
+### Rate limit analytics endpoint
+
+```http
+GET /rate-limits/analytics
+GET /rate-limits/analytics?tier=PREMIUM
+```
+
+Response:
+
+```json
+{
+  "rateLimits": {
+    "totalRequests": 54821,
+    "rateLimitHits": 142,
+    "hitRate": 0.0026,
+    "topThrottledKeys": [
+      { "key": "sk_live_abc123", "hits": 87 },
+      { "key": "sk_live_def456", "hits": 31 }
+    ],
+    "topThrottledEndpoints": [
+      { "endpoint": "POST /subscriptions", "hits": 95 },
+      { "endpoint": "GET /analytics", "hits": 47 }
+    ],
+    "byTier": {
+      "FREE":       { "requests": 12400, "hits": 98, "hitRate": 0.0079 },
+      "BASIC":      { "requests": 28600, "hits": 44, "hitRate": 0.0015 },
+      "PREMIUM":    { "requests": 11000, "hits": 0,  "hitRate": 0 },
+      "ENTERPRISE": { "requests": 2821,  "hits": 0,  "hitRate": 0 }
+    }
+  }
+}
+```
+
+### Rate limit status for a key
+
+```http
+GET /rate-limits/status?apiKey=sk_live_abc123&tier=BASIC
+```
+
+Response:
+
+```json
+{
+  "limits": {
+    "tier": "BASIC",
+    "hourlyLimit": 500,
+    "dailyLimit": 2500,
+    "monthlyLimit": 50000,
+    "burstLimit": 50,
+    "concurrentLimit": 5
+  },
+  "current": {
+    "hourly": 23,
+    "daily": 310,
+    "monthly": 4120,
+    "burstTokens": 42
+  },
+  "remaining": {
+    "hourly": 477,
+    "daily": 2190,
+    "monthly": 45880,
+    "burstTokens": 42
+  },
+  "resetAt": {
+    "hourly": 1722038400000,
+    "daily": 1722081600000,
+    "monthly": 1724630400000
+  }
+}
+```
+
+### Developer portal dashboard
+
+Navigate to **Developer Portal → Rate Limits** to see:
+- Hit rate over time (hourly chart)
+- Throttle rate by tier
+- Top throttled API keys
+- Top throttled endpoints
+- Guidance on reducing throttling
+
+---
+
+## Best Practices
+
+### Implement exponential back-off
+
+When you receive a `429` response, wait for the number of seconds indicated by `Retry-After` before retrying. Add jitter to avoid synchronized retry storms:
+
+```ts
+async function requestWithBackoff(fn: () => Promise<Response>, maxRetries = 5): Promise<Response> {
+  for (let i = 0; i < maxRetries; i++) {
+    const res = await fn();
+    if (res.status !== 429) return res;
+
+    const retryAfter = parseInt(res.headers.get('Retry-After') ?? '5', 10);
+    const jitter = Math.random() * 1000;
+    await new Promise(r => setTimeout(r, retryAfter * 1000 + jitter));
+  }
+  throw new Error('Max retries reached');
+}
+```
+
+### Cache responses
+
+Reduce request volume by caching API responses client-side. Subscription and plan data rarely changes more than once per minute.
+
+### Use webhooks for event-driven flows
+
+Instead of polling `GET /subscriptions` every few seconds, subscribe to webhook events like `subscription.updated` to receive real-time notifications without consuming rate-limit quota.
+
+### Monitor `X-RateLimit-Remaining`
+
+Log the `X-RateLimit-Remaining` header in your API client. Alert when it drops below 10% to give yourself time to throttle your own consumers before hitting the limit.
+
+### Batch where possible
+
+Use `POST /subscriptions/batch` and similar batch endpoints to reduce the number of individual API calls.
+
+---
+
+## API Reference
+
+### `GET /rate-limits/analytics`
+
+Returns aggregate rate-limiting analytics.
+
+**Query params:**
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `tier` | string | Filter to a specific tier (`FREE`, `BASIC`, `PREMIUM`, `ENTERPRISE`) |
+
+---
+
+### `GET /rate-limits/status`
+
+Returns the current rate-limit status for one API key.
+
+**Query params:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `apiKey` | string | Yes | The API key to inspect |
+| `tier` | string | No | Tier to apply (default: `FREE`) |
+
+---
+
+### `POST /rate-limits/bypass`
+
+Add or remove an entry from the bypass list.
+
+**Request body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `"key"` \| `"user"` | Yes | Whether to bypass an API key or a user ID |
+| `value` | string | Yes | The API key or user ID |
+| `action` | `"add"` \| `"remove"` | Yes | Whether to add or remove the entry |
+
+**Response:**
+
+```json
+{
+  "bypassKeys": ["sk_internal_abc123"],
+  "bypassUsers": ["user_svc_456"]
+}
+```
+
+---
+
+### `POST /rate-limits/config`
+
+Set custom rate limits for a specific API key.
+
+**Request body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `apiKey` | string | Yes | The API key to configure |
+| `limits.hourlyLimit` | number | No | Override hourly request limit |
+| `limits.dailyLimit` | number | No | Override daily request limit |
+| `limits.monthlyLimit` | number | No | Override monthly request limit |
+| `limits.burstLimit` | number | No | Override burst token bucket size |
+| `limits.concurrentLimit` | number | No | Override max concurrent requests |
+
+---
+
+## FAQ
+
+**Q: What happens when I hit the monthly limit?**  
+A: All requests are rejected with a `429` until the monthly window resets (~30 days from the first request of the month). Consider upgrading your tier.
+
+**Q: Do webhooks count against my rate limit?**  
+A: No. Inbound webhook callbacks from SubTrackr to your server do not consume your API quota.
+
+**Q: Can I increase limits without upgrading my tier?**  
+A: Yes, via custom per-key limits (see [Custom Limits per API Key](#custom-limits-per-api-key)). For sustained high volume, upgrading your tier is the better long-term solution.
+
+**Q: Are rate limits shared between test and production keys?**  
+A: No. Sandbox/test keys have separate quota buckets from production keys.
+
+**Q: How do I get real-time rate limit data in my dashboard?**  
+A: Read the `X-RateLimit-Remaining` and `X-RateLimit-Reset` headers from every API response, or poll `GET /rate-limits/status?apiKey=<key>` periodically.


### PR DESCRIPTION


Here's a PR description you can use:
  
  ───────────────────────────────────────────────────────────────────────────────────────────────
  
  feat: API Rate Limiting — per-user, per-key, analytics, config UI, and docs
  
  Summary
  
  Implements full API rate limiting for the SubTrackr backend API, covering all acceptance
  criteria: per-user limits, per-API-key limits, response headers, analytics, configuration UI,
  bypass for trusted clients, and documentation.
  
  ───────────────────────────────────────────────────────────────────────────────────────────────
  
  What was changed
  
  Backend — backend/services/shared/
  
  - rateLimitMiddleware.ts — new Express-compatible middleware that enforces rate limits on every
  request. Reads identity from X-API-Key, Authorization: Bearer, or X-User-ID headers; falls back
  to client IP. Sets standard X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
  Retry-After, and per-user X-UserRateLimit-* headers. Supports bypass paths, bypass key/user
  sets, and a soft mode (headers only, no rejection).
  - rateLimitingService.ts — enhanced with per-user aggregate rate limiting (5× the tier's
  per-key hourly limit), bypass management (addBypassKey, removeBypassKey, addBypassUser,
  removeBypassUser), per-key custom limit overrides (setCustomLimits, clearCustomLimits), and
  getRateLimitAnalytics() for throttle-specific reporting.
  - index.ts — exports the new middleware factory, status middleware, header constants, and
  types.
  
  Backend — backend/server.ts
  
  Wires the rate limit middleware to all non-health/metrics routes and adds four new endpoints:
  
  ┌────────┬──────┬─────────────┐
  │ Method │ Path │ Description │
  ├────────┼────────────────────────┼─────────────┤
  │ GET    │ /rate-limits/analytics │ Aggregate and per-tier rate limit analytics │
  ├────────┼────────────────────────┼─────────────────────────────────────────────┤
  │ GET    │ /rate-limits/status    │ Current quota status for a specific API key │
  ├────────┼────────────────────────┼─────────────────────────────────────────────┤
  │ POST   │ /rate-limits/bypass    │ Add or remove a key/user from the bypass list │
  ├────────┼────────────────────────┼───────────────────────────────────────────────┤
  │ POST   │ /rate-limits/config    │ Set custom limits for a specific API key      │
  └────────┴────────────────────────┴───────────────────────────────────────────────┘
  
  Developer Portal — developer-portal/src/
  
  - components/RateLimitConfigPanel.tsx — configuration panel with live usage progress bars,
  custom limit inputs (hourly/daily/monthly/burst/concurrent), bypass toggle per-key, and bypass
  list management. WCAG 2.1 AA accessible.
  - screens/RateLimitAnalyticsDashboard.tsx — full analytics screen showing overall hit rate,
  per-tier throttle breakdown, hourly trend chart (requests vs. throttles), top throttled API
  keys, top throttled endpoints, and actionable guidance.
  
  Docs — docs/rate-limiting.md
  
  Comprehensive reference covering tier limits table, how window counters and token buckets work,
  all response headers, error response format, soft-limit warnings, per-user limits, bypass
  configuration, custom limits, analytics endpoints, best practices (back-off, caching,
  webhooks), full API reference, and FAQ.
  
  Tests — backend/services/shared/__tests__/rateLimiting.test.ts
  
  Unit tests for RateLimitingService (rate checks, bypass, custom limits, per-user limits,
  analytics) and createRateLimitMiddleware (bypass paths, bypass keys, header injection, 429
  enforcement, soft mode, per-user headers, IP fallback, key extraction).
  
  ───────────────────────────────────────────────────────────────────────────────────────────────
  
  Rate limit tiers
  
  ┌──────┬────────┬───────┬─────────┬───────┬────────────┐
  │ Tier │ Hourly │ Daily │ Monthly │ Burst │ Concurrent │
  ├──────┼────────┼───────┼─────────┼───────┼────────────┤
  │ Free  │    100 │   500 │  10,000 │    20 │          2 │
  ├───────┼────────┼───────┼─────────┼───────┼────────────┤
  │ Basic │    500 │ 2,500 │  50,000 │    50 │          5 │
  ├─────────┼────────┼───────┼─────────┼───────┼────────────┤
  │ Premium    │  1,000 │ 10,000 │ 200,000 │   100 │         10 │
  ├────────────┼────────┼────────┼─────────┼───────┼────────────┤
  │ Enterprise │ 10,000 │ 100,000 │ 2,000,000 │   500 │         50 │
  └────────────┴────────┴─────────┴───────────┴───────┴────────────┘
  
  Per-user aggregate limits are 5× the per-key hourly limit and tracked independently.
  
  ───────────────────────────────────────────────────────────────────────────────────────────────
  
  Testing
  
  - Unit tests: npx jest --config jest.backend.config.js
  backend/services/shared/__tests__/rateLimiting.test.ts
  - Manual: start the server and hit GET /rate-limits/analytics, GET
  /rate-limits/status?apiKey=<key>, or any plan endpoint to see X-RateLimit-* headers in the
  response.

closes #714 
